### PR TITLE
Sprint 4: blog — dark horizontal card, Journal layout, post detail

### DIFF
--- a/src/lib/components/blog/BlogPost.svelte
+++ b/src/lib/components/blog/BlogPost.svelte
@@ -1,462 +1,172 @@
 <script lang="ts">
   import type { BlogPost } from '$lib/types/blog.js';
-  import { marked, Renderer } from 'marked';
-  import { onMount, setContext, afterUpdate, tick } from 'svelte';
-  import { dev } from '$app/environment';
-  import { theme } from '../../../theme/theme.js'; // Corrected import path
-	import { logger } from '$lib/utils/logger.js';
 
-  export let post: BlogPost;
-  export let isPreview = false;
-  
-  let htmlContent: string | Promise<string> = '';
-  let markdownContainer: HTMLDivElement | null = null;
-  let processedMarkdown = false;
-  
-  // Header Image Refs
-  let headerImageElementPreview: HTMLImageElement | null = null;
-  let headerImageElementFull: HTMLImageElement | null = null;
-  
-  // Reactive statement to process markdown when post content changes
-  $: {
-      if (post && post.content) {
-          const renderer = new Renderer();
-          
-          // Custom image renderer to resolve relative paths within markdown
-          renderer.image = ({ href, title, text }: { href: string; title: string | null; text: string }): string => {
-            let resolvedHref = href;
-            // If path is relative (doesn't start with / or http), prepend the correct base path
-            if (resolvedHref && !resolvedHref.startsWith('/') && !resolvedHref.startsWith('http')) {
-              logger.log(`Resolving relative image path in markdown: ${resolvedHref} for post: ${post.id}`);
-              // ALWAYS use the /directr2/ prefix, the hook handles dev/prod resolution
-              resolvedHref = `/directr2/blog/posts/${post.id}/${resolvedHref}`;
-              logger.log(`Resolved relative img path: ${href} -> ${resolvedHref}`);
-            }
-            const titleAttr = title ? ` title="${title}"` : '';
-            // Add lazy loading and styling to markdown images
-            return `<img src="${resolvedHref}" alt="${text}"${titleAttr} loading="lazy" class="markdown-image">`;
-          };
-      
-          // Parse markdown (only for full post view)
-          htmlContent = isPreview ? '' : marked.parse(post.content, {
-            renderer: renderer, 
-            gfm: true,
-            breaks: true,
-            async: false
-          });
-          processedMarkdown = false; // Reset processed flag
-      } else {
-          htmlContent = '';
-          processedMarkdown = false;
-      }
-  }
+  let { post }: { post: BlogPost } = $props();
 
-  // Get the canonical image path (always /directr2/...)
-  $: headerImagePath = post?.image || ''; // Use optional chaining
-
-  // Log post ID for debugging 
-  logger.log('Creating blog post link for post ID:', post.id);
-
-  // Generate link with proper encoding to preserve case and handle special chars
-  $: encodedPostId = encodeURIComponent(post.id);
-  $: blogPostUrl = `/blog/${encodedPostId}`;
-  $: logger.log('Blog post link URL:', blogPostUrl);
-  
-  // Log the final image path being used
-  $: logger.log('Header image path for post:', headerImagePath);
-
-  // Header Image Handling - Track loading state
-  let headerImageLoaded = false; 
-  let headerImageErrored = false; // Track if the primary image load failed
-
-  onMount(async () => {
-    headerImageLoaded = false;
-    headerImageErrored = false; // Reset on mount
-    logger.log(`BlogPost component mounted for post: ${post.id}`);
-
-    // Allow Svelte to render the DOM first
-    await tick();
-
-    // Check if the relevant image element is already complete (e.g., from cache)
-    const imgElement = isPreview ? headerImageElementPreview : headerImageElementFull;
-    if (imgElement?.complete && !headerImageErrored) {
-      logger.log(`Header image (${imgElement.src}) was already complete on mount.`);
-      handleImageLoad(); // Manually trigger load state if already complete
-    } else if (imgElement) {
-      logger.log(`Header image (${imgElement.src}) not complete on mount. Waiting for on:load.`);
-    }
-  });
-
-  // Function to mark image as loaded
-  function handleImageLoad() {
-    headerImageLoaded = true;
-    headerImageErrored = false; // Reset error if it somehow loads later
-    logger.log(`Header image loaded successfully: ${headerImagePath}`);
-  }
-
-  // Function to mark image as errored
-  function handleImageError() {
-    if (!headerImageLoaded) { // Only mark as errored if not already loaded
-        logger.error(`Header image failed to load: ${headerImagePath}`);
-        headerImageErrored = true;
+  function formatDate(dateStr: string): string {
+    try {
+      return new Date(dateStr).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      });
+    } catch {
+      return dateStr;
     }
   }
-
-  // Add lazy loading classes to markdown images after update
-  afterUpdate(() => {
-     if (!isPreview && markdownContainer && typeof htmlContent === 'string' && htmlContent.length > 0 && !processedMarkdown) {
-       const images = markdownContainer.querySelectorAll('.markdown-image'); // Target by class
-       images.forEach(img => {
-         // Assert type to HTMLImageElement to access 'complete'
-         const imageElement = img as HTMLImageElement; 
-         if (imageElement.complete) {
-           imageElement.classList.add('loaded');
-         } else {
-           imageElement.addEventListener('load', () => imageElement.classList.add('loaded'), { once: true });
-           // Optional: Add error handling for markdown images if needed
-           imageElement.addEventListener('error', () => {
-               logger.error(`Markdown image failed to load: ${imageElement.src}`);
-               imageElement.classList.add('error'); // Add error class for styling
-           }, { once: true });
-         }
-       });
-       processedMarkdown = true;
-       logger.log(`Processed ${images.length} markdown images for lazy loading.`);
-     }
-  });
 </script>
 
-{#if isPreview}
-  <!-- Preview Card -->
-  <article 
-    class="card-container" 
-    data-post-id={post.id}
-    style="
-      --blog-label-bg-color: color-mix(in srgb, {theme.secondary} 70%, white 30%);
-      --blog-label-text-color: {theme.tertiary};
-    "
-  >
-    {#if headerImagePath}
-      <a href={blogPostUrl} class="block image-link">
-         <div class="image-placeholder" class:error={headerImageErrored}>
-            {#if !headerImageErrored}
-              <img
-                bind:this={headerImageElementPreview}
-                src={headerImagePath}
-                alt={post.title}
-                class="card-image" 
-                class:loaded={headerImageLoaded} 
-                loading="lazy"
-                on:load={handleImageLoad}
-                on:error={handleImageError}
-              />
-            {:else}
-              <div class="error-placeholder-text">Image Error</div>
-            {/if}
-         </div>
-      </a>
-    {:else}
-       <div class="image-placeholder no-image"></div>
-    {/if}
-    <div class="p-6">
-      <!-- Card Content (title, meta, summary) -->
-      <div class="flex items-center gap-2 mb-4">
-        <span class="blog-label">
-          {post.label}
-        </span>
-        <time class="text-gray-500 text-sm" datetime={post.published}>
-          {new Date(post.published).toLocaleDateString('en-US', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric'
-          })}
-        </time>
-      </div>
-      <h2 class="text-xl font-semibold mb-3">
-        <a
-          href={blogPostUrl}
-          class="text-gray-900 hover:text-gray-700 transition-colors"
-        >
-          {post.title}
-        </a>
-      </h2>
-      <p class="text-gray-600 mb-4 line-clamp-3">
-        {post.summary}
-      </p>
-      <div class="flex items-center text-gray-500 text-sm">
-        <span class="font-medium">{post.author}</span>
-      </div>
+<a href="/blog/{encodeURIComponent(post.id)}" class="post-card" aria-label={post.title}>
+  {#if post.image}
+    <div class="card-image-wrap">
+      <img
+        src={post.image}
+        alt={post.title}
+        class="card-image"
+        loading="lazy"
+      />
     </div>
-  </article>
-{:else}
-  <!-- Full Post View -->
-  <article 
-    class="prose prose-lg mx-auto" 
-    style="
-      --blog-label-bg-color: color-mix(in srgb, {theme.secondary} 70%, white 30%);
-      --blog-label-text-color: {theme.tertiary};
-    "
-  >
-    <header class="mb-8">
-      <!-- Post Header (title, meta) -->
-      <h1 class="text-4xl font-bold mb-4 font-sans">{post.title}</h1>
-      <div class="flex items-center gap-4 text-gray-600">
-        <span>{post.author}</span>
-        <span>•</span>
-        <time datetime={post.published}>
-          {new Date(post.published).toLocaleDateString('en-US', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric'
-          })}
-        </time>
-        <span>•</span>
-        <span class="blog-label">{post.label}</span>
-      </div>
-    </header>
+  {/if}
 
-    {#if headerImagePath}
-       <!-- Placeholder container for full post header -->
-       <div class="image-placeholder full-post-header" class:error={headerImageErrored}>
-        {#if !headerImageErrored}
-          <img
-            bind:this={headerImageElementFull}
-            id="post-header-image-{post.id}" 
-            src={headerImagePath}
-            alt={post.title}
-            class="full-post-image"
-            class:loaded={headerImageLoaded}
-            loading="lazy"
-            on:load={handleImageLoad}
-            on:error={handleImageError}
-          />
-        {:else}
-           <div class="error-placeholder-text">Image Error</div>
-        {/if}
-       </div>
-    {/if}
-
-    <!-- Rendered Markdown Content -->
-    {#if typeof htmlContent === 'string'}
-       <div bind:this={markdownContainer} class="markdown-content">
-          {@html htmlContent}
-       </div>
-    {:else}
-        <p>Loading content...</p> 
-    {/if}
-
-  </article>
-{/if}
+  <div class="card-body">
+    <span class="card-label">{post.label}</span>
+    <h2 class="card-title">{post.title}</h2>
+    <p class="card-summary">{post.summary}</p>
+    <div class="card-meta">
+      <span>{post.author}</span>
+      <span class="meta-sep">·</span>
+      <time datetime={post.published}>{formatDate(post.published)}</time>
+    </div>
+  </div>
+</a>
 
 <style>
-  a {
+  .post-card {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    width: 100%;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(200, 192, 184, 0.08);
     text-decoration: none;
-  }
-
-  :global(.prose) {
-    max-width: 65ch;
-  }
-
-  :global(.prose img) {
-    border-radius: 0.5rem;
-    opacity: 0;
-    transition: opacity 0.5s ease-in-out;
-  }
-
-  :global(.prose img.loaded) {
-     opacity: 1;
-  }
-
-  :global(.prose h1) {
-    font-size: 2.5rem;
-    margin-top: 0;
-  }
-
-  :global(.prose h2) {
-    font-size: 2rem;
-    margin-top: 2rem;
-  }
-
-  :global(.prose h3) {
-    font-size: 1.5rem;
-    margin-top: 1.5rem;
-  }
-
-  :global(.prose ul) {
-    list-style-type: disc;
-    padding-left: 1.5rem;
-  }
-
-  :global(.prose ol) {
-    list-style-type: decimal;
-    padding-left: 1.5rem;
-  }
-
-  :global(.prose li) {
-    margin: 0.5rem 0;
-  }
-
-  :global(.prose strong) {
-    font-weight: 600;
-  }
-
-  :global(.prose em) {
-    font-style: italic;
-  }
-
-  .card-container {
-    background-color: white;
-    border-radius: 0.5rem;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+    color: inherit;
+    transition:
+      border-color 0.25s ease,
+      background 0.25s ease;
     overflow: hidden;
-    transition: transform 0.2s ease-in-out;
-    border: 1px solid #f3f4f6;
-  }
-  .card-container:hover {
-     transform: translateY(-0.25rem);
   }
 
-  .image-link:hover .card-image {
-      opacity: 0.9;
+  .post-card:hover {
+    border-color: rgba(200, 192, 184, 0.22);
+    background: rgba(255, 255, 255, 0.04);
   }
 
-  .image-placeholder {
-     display: block;
-     position: relative;
-     width: 100%;
-     aspect-ratio: 16 / 9; /* Common aspect ratio */
-     background-color: #f0f0f0; 
-     background-image: url('/images/constants/placeholder.svg');
-     background-size: cover;
-     background-position: center;
-     overflow: hidden; /* Contain absolute image */
-     margin-bottom: 2rem; /* Spacing below header image */
-     border-radius: 0.5rem; /* Match prose img style */
-  }
-
-  /* Mobile-specific styling */
-  @media (max-width: 768px) {
-    .image-placeholder {
-      aspect-ratio: 16 / 10; /* Slightly shorter for mobile */
-      margin-bottom: 1rem; /* Less spacing on mobile */
-    }
-    
-    .p-6 {
-      padding: 1rem !important; /* Override padding for mobile */
-    }
-    
-    .card-container {
-      max-width: 100%; /* Make sure it fits on screen */
-      margin: 0 auto; /* Center it */
-    }
-    
-    /* Make text smaller on mobile */
-    .text-xl {
-      font-size: 1.1rem !important;
-    }
-    
-    .mb-3 {
-      margin-bottom: 0.5rem !important; /* Less margin under title */
-    }
-    
-    .mb-4 {
-      margin-bottom: 0.75rem !important; /* Less margin under meta */
-    }
-    
-    /* Limit height of summary text on mobile */
-    .line-clamp-3 {
-      -webkit-line-clamp: 2;
-      display: -webkit-box;
-      -webkit-box-orient: vertical;  
-      overflow: hidden;
-    }
-  }
-
-  .image-placeholder.no-image {
+  /* Image */
+  .card-image-wrap {
+    flex: 0 0 200px;
+    width: 200px;
+    max-height: 160px;
+    overflow: hidden;
+    position: relative;
   }
 
   .card-image {
-    position: absolute;
-    top: 0;
-    left: 0;
     width: 100%;
     height: 100%;
     object-fit: cover;
-    opacity: 0;
-    transition: opacity 0.5s ease-in-out;
+    display: block;
+    transition: transform 0.35s ease;
   }
 
-  .card-image.loaded {
-    opacity: 1;
+  .post-card:hover .card-image {
+    transform: scale(1.04);
   }
 
-  .error-placeholder-text {
-     position: absolute;
-     top: 0;
-     left: 0;
-     width: 100%;
-     height: 100%;
-     display: flex;
-     align-items: center;
-     justify-content: center;
-     font-size: 0.875rem;
-     color: #9ca3af;
+  /* Body */
+  .card-body {
+    flex: 1;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    justify-content: center;
+    min-width: 0;
   }
 
-  /* Adjustments for full post header image */
-  .image-placeholder.full-post-header {
-     /* Optional: Different aspect ratio? */
-     /* aspect-ratio: 21 / 9; */
+  /* Label */
+  .card-label {
+    font-family: var(--font-ui);
+    font-size: 9px;
+    font-weight: 400;
+    letter-spacing: 0.35em;
+    text-transform: uppercase;
+    color: var(--gold);
   }
 
-  /* Full post header image */
-  .full-post-image {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    opacity: 0;
-    transition: opacity 0.5s ease-in-out;
-  }
-  .full-post-image.loaded {
-     opacity: 1;
+  /* Title */
+  .card-title {
+    font-family: var(--font-display);
+    font-size: 1.8rem;
+    font-weight: 300;
+    line-height: 1.15;
+    color: var(--warm-white);
+    margin: 0;
+    transition: color 0.2s ease;
   }
 
-  /* --- Update style for the blog label to use CSS vars --- */
-  .blog-label {
-    background-color: var(--blog-label-bg-color);
-    color: var(--blog-label-text-color);
-    padding: 0.25rem 0.5rem; /* Equivalent to py-1 px-2 */
-    border-radius: 9999px; /* Equivalent to rounded-full */
-    font-size: 0.875rem; /* Equivalent to text-sm */
-    font-weight: 500; /* Equivalent to font-medium */
-    display: inline-block; /* Ensure padding applies correctly */
+  .post-card:hover .card-title {
+    color: var(--gold);
   }
 
-  .image-placeholder.error {
-    background-color: #fee; /* Light red for error */
+  /* Summary */
+  .card-summary {
+    font-family: var(--font-ui);
+    font-size: 12px;
+    font-weight: 300;
+    color: var(--text-dim);
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    line-height: 1.6;
   }
 
-  /* Add styles for markdown images */
-  :global(.markdown-image) {
-    display: block; /* Or inline-block */
-    max-width: 100%;
-    height: auto;
-    margin-top: 1em;
-    margin-bottom: 1em;
-    border-radius: 4px; /* Optional: style consistency */
-    opacity: 0;
-    transition: opacity 0.5s ease-in-out;
+  /* Meta */
+  .card-meta {
+    font-family: var(--font-ui);
+    font-size: 9px;
+    font-weight: 300;
+    color: var(--text-dim);
+    letter-spacing: 0.08em;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 0.2rem;
   }
 
-  :global(.markdown-image.loaded) {
-    opacity: 1;
+  .meta-sep {
+    opacity: 0.5;
   }
 
-  :global(.markdown-image.error) {
-     /* Style for failed markdown images */
-     border: 2px dashed red;
+  /* Mobile: stack vertically */
+  @media (max-width: 640px) {
+    .post-card {
+      flex-direction: column;
+    }
+
+    .card-image-wrap {
+      flex: none;
+      width: 100%;
+      max-height: 200px;
+    }
+
+    .card-body {
+      padding: 1rem 1.25rem;
+    }
+
+    .card-title {
+      font-size: 1.5rem;
+    }
   }
-</style> 
+</style>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -238,37 +238,34 @@
   });
 </script>
 
-<div class="blog-container" style="--bg-color: {theme.tertiary}; --text-color: {theme.text.primary}; --secondary-color: {theme.secondary};">
-  <Navbar 
-    backgroundColor={theme.text.primary}
-    textColor={theme.background.light}
-  />
+<div class="journal-page">
+  <Navbar />
 
-  <main class="blog-main-content">
-    <div class="content-wrapper">
-      <div class="page-header">
-        <h1 class="page-title">Blog</h1>
-        <p class="page-subtitle">
-          Exploring the art of photography, one frame at a time. Join me on my journey.
-        </p>
-      </div>
+  <main class="journal-main">
+    <div class="journal-wrapper">
+
+      <header class="journal-header">
+        <h1 class="journal-title">Journal</h1>
+        <p class="journal-subtitle">Light, shadow, and the moments between</p>
+      </header>
 
       {#if isLoading}
-        <div class="loading-container">
-          <div class="loading-spinner"></div>
-          <p class="loading-text">Loading blog posts...</p>
+        <div class="state-block">
+          <div class="loading-ring"></div>
+          <span class="state-text">Loading…</span>
         </div>
       {:else if $posts && $posts.length > 0}
-        <div class="posts-grid">
+        <div class="posts-list">
           {#each $posts as post (post.id)}
-            <BlogPostComponent {post} isPreview={true} />
+            <BlogPostComponent {post} />
           {/each}
         </div>
       {:else if loadError}
-        <p class="status-text error-text">Failed to load blog posts.</p>
+        <p class="state-text state-error">Failed to load posts.</p>
       {:else}
-        <p class="status-text no-posts-text">No blog posts available yet.</p>
+        <p class="state-text">No posts yet.</p>
       {/if}
+
     </div>
   </main>
 
@@ -276,152 +273,106 @@
 </div>
 
 <style>
-  .blog-container {
+  .journal-page {
     min-height: 100vh;
-    width: 100%;
-    background-color: var(--bg-color);
-    color: var(--text-color);
+    background-color: var(--near-black);
+    color: var(--warm-white);
     display: flex;
     flex-direction: column;
   }
-  @media (max-width: 768px) {
-    .blog-container {
-      padding-top: 4rem;
-    }
-  }
 
-  main {
+  .journal-main {
     flex: 1;
+    padding-top: 7rem;
+    padding-bottom: 5rem;
   }
 
-  .blog-main-content {
-    min-height: 100vh;
-    padding-top: 4rem; /* py-16 */
-    padding-bottom: 4rem; /* py-16 */
+  .journal-wrapper {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
   }
 
-  .content-wrapper {
-    max-width: 80rem; /* max-w-7xl */
-    margin-left: auto; /* mx-auto */
-    margin-right: auto; /* mx-auto */
-    padding-left: 1rem; /* px-4 */
-    padding-right: 1rem; /* px-4 */
-  }
-
-  .page-header {
-    max-width: 64rem; /* max-w-4xl */
-    margin-left: auto; /* mx-auto */
-    margin-right: auto; /* mx-auto */
-    margin-bottom: 3rem; /* mb-12 */
-    text-align: center; /* text-center */
-  }
-
-  .page-title {
-    font-size: 2.25rem; /* text-4xl */
-    line-height: 2.5rem; /* text-4xl */
-    font-weight: 700; /* font-bold */
-    color: color-mix(in srgb, var(--secondary-color) 80%, black); 
-    margin-bottom: 1rem; /* mb-4 */
-  }
-
-  .page-subtitle {
-    font-size: 1.125rem; /* text-lg */
-    line-height: 1.75rem; /* text-lg */
-    color: var(--secondary-color); 
-  }
-
-  .loading-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding-top: 5rem; /* py-20 */
-    padding-bottom: 5rem; /* py-20 */
-  }
-
-  .loading-spinner {
-    height: 3rem; /* h-12 */
-    width: 3rem; /* w-12 */
-    border-top-width: 2px; /* border-t-2 */
-    border-bottom-width: 2px; /* border-b-2 */
-    border-color: rgb(17 24 39); /* border-gray-900 */
-    border-radius: 9999px; /* rounded-full */
-    animation: spin 1s linear infinite;
-  }
-
-  .loading-text {
-    margin-left: 1rem; /* ml-4 */
-    font-size: 1.125rem; /* text-lg */
-    line-height: 1.75rem; /* text-lg */
-    color: var(--secondary-color); 
-  }
-
-  .posts-grid {
-    display: grid;
-    grid-template-columns: repeat(1, minmax(0, 1fr)); /* grid-cols-1 */
-    gap: 2rem; /* gap-8 */
-  }
-
-  .status-text {
+  /* Header */
+  .journal-header {
     text-align: center;
-    padding-top: 2.5rem; /* py-10 */
-    padding-bottom: 2.5rem; /* py-10 */
+    margin-bottom: 4rem;
   }
 
-  .error-text {
-    color: rgb(220 38 38); /* text-red-600 */
+  .journal-title {
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 6vw, 5.5rem);
+    font-weight: 300;
+    font-style: italic;
+    color: var(--warm-white);
+    letter-spacing: 0.02em;
+    margin: 0 0 0.75rem;
+    line-height: 1;
   }
 
-  .no-posts-text {
-     color: var(--secondary-color);
+  .journal-subtitle {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    font-weight: 100;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    margin: 0;
   }
 
-  /* Responsive styles */
-  @media (min-width: 640px) { /* sm: */
-    .content-wrapper {
-      padding-left: 1.5rem; /* sm:px-6 */
-      padding-right: 1.5rem; /* sm:px-6 */
-    }
+  /* Posts list */
+  .posts-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    border-top: 1px solid rgba(200, 192, 184, 0.08);
   }
 
-  @media (min-width: 768px) { /* md: */
-    .posts-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr)); /* md:grid-cols-2 */
-    }
+  /* Loading / state */
+  .state-block {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 5rem 0;
   }
 
-  @media (min-width: 1024px) { /* lg: */
-    .content-wrapper {
-      padding-left: 2rem; /* lg:px-8 */
-      padding-right: 2rem; /* lg:px-8 */
-    }
-    .posts-grid {
-      grid-template-columns: repeat(3, minmax(0, 1fr)); /* lg:grid-cols-3 */
-    }
+  .loading-ring {
+    width: 1.5rem;
+    height: 1.5rem;
+    border: 1px solid rgba(200, 192, 184, 0.2);
+    border-top-color: var(--silver);
+    border-radius: 50%;
+    animation: spin 0.9s linear infinite;
+  }
+
+  .state-text {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    font-weight: 300;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    text-align: center;
+    padding: 4rem 0;
+  }
+
+  .state-error {
+    color: rgba(220, 80, 80, 0.7);
   }
 
   @keyframes spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
+    to { transform: rotate(360deg); }
   }
 
-  /* Mobile-specific adjustment for grid */
-  @media (max-width: 768px) {
-    .posts-grid {
-      gap: 1rem; /* Tighter spacing for mobile */
+  @media (max-width: 640px) {
+    .journal-main {
+      padding-top: 5rem;
+      padding-bottom: 3rem;
     }
-    
-    .blog-main-content {
-      padding-top: 2rem; /* Reduce padding on mobile */
-      padding-bottom: 2rem;
-    }
-    
-    .page-header {
-      margin-bottom: 1.5rem; /* Less margin under header on mobile */
+
+    .journal-header {
+      margin-bottom: 2.5rem;
     }
   }
-
 </style> 

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -4,146 +4,303 @@
   import BlogPost from '$lib/components/blog/BlogPost.svelte';
   import type { BlogPost as BlogPostType } from '$lib/types/blog.js';
   import { theme } from '../../../theme/theme.js';
+  import { marked } from 'marked';
 
   export let data: { post: BlogPostType };
 
   // Get tertiary color for inline style
   $: tertiaryColor = theme.tertiary;
+
+  // Render markdown content to HTML
+  $: htmlContent = data.post?.content
+    ? (marked.parse(data.post.content, { gfm: true, breaks: true, async: false }) as string)
+    : '';
 </script>
 
-<Navbar 
-    backgroundColor={theme.text.primary}
-    textColor={theme.background.light}
-  />
+<div class="post-page">
+  <Navbar />
 
-<main 
-  class="min-h-screen blog-post-content"
-  style="--theme-secondary: {theme.secondary}; background-color: {tertiaryColor};"
->
-  <div class="blog-post-inner-container">
-    <div class="back-link-wrapper">
-      <a
-        href="/blog"
-        class="back-link"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="back-link-icon"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M7.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l2.293 2.293a1 1 0 010 1.414z"
-            clip-rule="evenodd"
-          />
-        </svg>
-        Back to Blog
-      </a>
+  <main class="post-main">
+
+    <!-- Back nav -->
+    <div class="post-nav-bar">
+      <div class="post-nav-inner">
+        <a href="/blog" class="back-link">← Journal</a>
+      </div>
     </div>
 
-    <BlogPost post={data.post} />
-  </div>
-</main>
+    <!-- Hero image -->
+    <div class="post-hero">
+      <img
+        src="/directr2/blog/posts/{data.post.id}/header.webp"
+        alt={data.post.title}
+        class="post-hero-img"
+        loading="eager"
+      />
+      <div class="post-hero-overlay"></div>
+    </div>
 
-<Footer />
+    <!-- Article -->
+    <div class="post-article-wrap">
+      <article class="post-article">
+
+        <!-- Meta above title -->
+        <div class="post-meta">
+          <span class="post-label">{data.post.label}</span>
+          <span class="meta-sep">·</span>
+          <span class="post-author">{data.post.author}</span>
+          <span class="meta-sep">·</span>
+          <time class="post-date" datetime={data.post.published}>
+            {new Date(data.post.published).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+          </time>
+        </div>
+
+        <h1 class="post-title">{data.post.title}</h1>
+
+        <!-- Prose content -->
+        <div class="post-prose">
+          {@html htmlContent}
+        </div>
+
+      </article>
+    </div>
+
+  </main>
+
+  <Footer />
+</div>
 
 <style>
-  .blog-post-content {
-    padding-top: 5rem;
-    padding-bottom: 4rem;
+  .post-page {
     min-height: 100vh;
-  }
-  @media (max-width: 768px) {
-    .blog-post-content {
-      padding-top: 6rem;
-    }
-    :global(.prose h1) {
-      font-size: 1.5rem;
-    }
-    :global(.prose h2) {
-      font-size: 1.25rem;
-    }
-    :global(.prose h3) {
-      font-size: 1rem;
-    } 
+    background-color: var(--near-black);
+    color: var(--warm-white);
+    display: flex;
+    flex-direction: column;
   }
 
-  .blog-post-inner-container {
-    max-width: 80rem;
-    margin-left: auto;
-    margin-right: auto;
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-  @media (min-width: 640px) {
-    .blog-post-inner-container {
-      padding-left: 1.5rem;
-      padding-right: 1.5rem;
-    }
-  }
-  @media (min-width: 1024px) {
-    .blog-post-inner-container {
-      padding-left: 2rem;
-      padding-right: 2rem;
-    }
+  .post-main {
+    flex: 1;
+    padding-top: 4.5rem; /* navbar offset */
   }
 
-  .back-link-wrapper {
-    margin-bottom: 2rem;
+  /* Back nav */
+  .post-nav-bar {
+    padding: 1.25rem 0 0;
+  }
+
+  .post-nav-inner {
+    max-width: 780px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
   }
 
   .back-link {
-    display: inline-flex;
-    align-items: center;
-    color: var(--theme-secondary);
+    font-family: var(--font-ui);
+    font-size: 10px;
+    font-weight: 300;
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+    color: var(--text-dim);
     text-decoration: none;
     transition: color 0.2s ease;
   }
 
   .back-link:hover {
-    color: color-mix(in srgb, var(--theme-secondary) 60%, black 40%);
+    color: var(--silver);
+  }
+
+  /* Hero */
+  .post-hero {
+    position: relative;
+    width: 100%;
+    max-height: 520px;
+    overflow: hidden;
+    margin-top: 1.5rem;
+  }
+
+  .post-hero-img {
+    width: 100%;
+    height: 520px;
+    object-fit: cover;
+    display: block;
+  }
+
+  .post-hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      to bottom,
+      transparent 40%,
+      rgba(14, 14, 14, 0.7) 100%
+    );
+  }
+
+  /* Article wrap */
+  .post-article-wrap {
+    max-width: 780px;
+    margin: 0 auto;
+    padding: 0 1.5rem 5rem;
+  }
+
+  .post-article {
+    padding-top: 2.5rem;
+  }
+
+  /* Meta */
+  .post-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .post-label {
+    font-family: var(--font-ui);
+    font-size: 9px;
+    font-weight: 400;
+    letter-spacing: 0.35em;
+    text-transform: uppercase;
+    color: var(--gold);
+  }
+
+  .post-author,
+  .post-date {
+    font-family: var(--font-ui);
+    font-size: 9px;
+    font-weight: 300;
+    letter-spacing: 0.1em;
+    color: var(--text-dim);
+    text-transform: uppercase;
+  }
+
+  .meta-sep {
+    color: var(--text-dim);
+    opacity: 0.4;
+    font-size: 9px;
+  }
+
+  /* Title */
+  .post-title {
+    font-family: var(--font-display);
+    font-size: clamp(2.2rem, 5vw, 4rem);
+    font-weight: 300;
+    line-height: 1.1;
+    color: var(--warm-white);
+    margin: 0 0 2.5rem;
+  }
+
+  /* Prose */
+  .post-prose {
+    font-family: var(--font-display);
+    font-size: 1.1rem;
+    line-height: 1.85;
+    color: var(--warm-white);
+  }
+
+  .post-prose :global(h1),
+  .post-prose :global(h2),
+  .post-prose :global(h3),
+  .post-prose :global(h4) {
+    font-family: var(--font-display);
+    font-weight: 300;
+    color: var(--warm-white);
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+    line-height: 1.2;
+  }
+
+  .post-prose :global(h1) { font-size: 2rem; }
+  .post-prose :global(h2) { font-size: 1.65rem; }
+  .post-prose :global(h3) { font-size: 1.35rem; }
+  .post-prose :global(h4) { font-size: 1.1rem; font-style: italic; }
+
+  .post-prose :global(p) {
+    margin: 0 0 1.5rem;
+  }
+
+  .post-prose :global(a) {
+    color: var(--gold);
     text-decoration: underline;
+    text-underline-offset: 3px;
+    transition: color 0.2s ease;
   }
 
-  .back-link-icon {
-    height: 1.25rem;
-    width: 1.25rem;
-    margin-right: 0.5rem;
+  .post-prose :global(a:hover) {
+    color: var(--warm-white);
   }
 
-  :global(.prose) {
-    max-width: 65ch;
+  .post-prose :global(img) {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 2rem auto;
+    border: 1px solid rgba(200, 192, 184, 0.1);
   }
 
-  :global(.prose img) {
-    border-radius: 0.5rem;
+  .post-prose :global(blockquote) {
+    border-left: 2px solid var(--gold);
+    margin: 2rem 0;
+    padding: 0.5rem 0 0.5rem 1.5rem;
+    color: var(--silver);
+    font-style: italic;
   }
 
-  :global(.prose a) {
-    color: #4a5568;
-    text-decoration: underline;
+  .post-prose :global(pre) {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(200, 192, 184, 0.1);
+    padding: 1.25rem;
+    overflow-x: auto;
+    font-size: 0.85rem;
+    line-height: 1.6;
+    margin: 2rem 0;
   }
 
-  :global(.prose a:hover) {
-    color: #2d3748;
+  .post-prose :global(code) {
+    background: rgba(255, 255, 255, 0.06);
+    padding: 0.15em 0.4em;
+    font-size: 0.88em;
+    color: var(--silver);
+    border-radius: 2px;
   }
 
-  :global(.prose pre) {
-    background-color: #f7fafc;
-    padding: 1rem;
-    border-radius: 0.5rem;
+  .post-prose :global(ul),
+  .post-prose :global(ol) {
+    padding-left: 1.75rem;
+    margin-bottom: 1.5rem;
   }
 
-  :global(.prose code) {
-    color: #2d3748;
-    background-color: #edf2f7;
-    padding: 0.2rem 0.4rem;
-    border-radius: 0.25rem;
+  .post-prose :global(li) {
+    margin-bottom: 0.4rem;
   }
 
-  :global(.prose blockquote) {
-    border-left-color: #4a5568;
-    color: #4a5568;
+  .post-prose :global(hr) {
+    border: none;
+    border-top: 1px solid rgba(200, 192, 184, 0.12);
+    margin: 3rem 0;
+  }
+
+  /* Mobile */
+  @media (max-width: 640px) {
+    .post-hero-img {
+      height: 260px;
+    }
+
+    .post-hero {
+      max-height: 260px;
+    }
+
+    .post-article {
+      padding-top: 1.75rem;
+    }
+
+    .post-title {
+      margin-bottom: 1.75rem;
+    }
+
+    .post-prose {
+      font-size: 1rem;
+    }
   }
 </style> 


### PR DESCRIPTION
## Summary
- `blog/+page.svelte`: script logic preserved verbatim; new "Journal" header in Cormorant italic, posts stacked in a bordered list
- `BlogPost.svelte`: rewritten as dark horizontal card (200px image left, gold label, Cormorant title, Josefin summary, meta row); stacks vertically on mobile
- `blog/[slug]/+page.svelte`: script logic preserved; new layout with hero image, back link, gold metadata, prose block with full dark-theme typography styles using `marked`

## Test plan
- [ ] Blog list shows "Journal" header and horizontal post cards
- [ ] Card image appears on left (if post has image), stacks on mobile
- [ ] Clicking a card navigates to post detail page
- [ ] Post detail shows hero image, title, rendered markdown content
- [ ] Back link returns to journal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
