### PR TITLE
Sprint 5: about + prints — Darkroom aesthetic restyle

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,148 +1,228 @@
 <script lang="ts">
-  import { theme } from '../../theme/theme.js';
-  import { Footer } from "$lib/components/ui";
-  import { Navbar } from "$lib/components/ui";
+  import Navbar from '$lib/components/ui/navbar.svelte';
+  import Footer from '$lib/components/ui/footer.svelte';
 
   const profileImage = '/directr2/constants/Profile_Pic.webp';
   const fallbackProfileImage = '/images/constants/Profile_Pic.webp';
   let profileImageError = $state(false);
 </script>
 
-<div class="about-container" style="--bg-color: {theme.background.light}; --text-color: {theme.text.primary}; --secondary-color: {theme.secondary};">
-  <Navbar 
-    backgroundColor={theme.text.primary}
-    textColor={theme.background.light}
-  />
-  <div class="about-content">
-    {#if !profileImageError}
-      <img 
-        src={profileImage} 
-        alt="Profile" 
-        class="profile-photo" 
-        onerror={() => {
-          console.log('Profile image failed to load, trying fallback');
-          profileImageError = true;
-        }}
-      />
-    {:else}
-      <img 
-        src={fallbackProfileImage} 
-        alt="Profile" 
-        class="profile-photo"
-        onerror={() => {
-          console.error('Both profile image paths failed');
-        }}
-      />
-    {/if}
-    <div class="text-content">
-      <h1>About Me</h1>
-      <p>
-        Alain is a photographer with a love for visual storytelling. 
-        Originally from New Jersey and now based in Seattle, he brings four years of photographic experience to his work, 
-        including three years immersed in the art of film. 
-        Whether in vivid color or classic black and white, he seeks to capture a collection of awe inspiring images.
-      </p>
-      <p class="quote">
-        "I try best to capture feelings and essence through the images I take, to invoke some sort of emotion in the viewer. 
-        It's because of this, that I have a hard time categorizing my work, it's more a collection of such. 
-        I find joy in being able to see the changes in what caught my eye, and also bring back memories of what exactly it was that excited me. 
-        Hopefully, through this, you'll be excited to see what I've been up to."
-      </p>
+<div class="about-page">
+  <Navbar />
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-image-wrap">
+        {#if !profileImageError}
+          <img
+            src={profileImage}
+            alt="Alain"
+            class="hero-img"
+            onerror={() => { profileImageError = true; }}
+          />
+        {:else}
+          <img
+            src={fallbackProfileImage}
+            alt="Alain"
+            class="hero-img"
+            onerror={() => { console.error('Both profile image paths failed'); }}
+          />
+        {/if}
+      </div>
+
+      <div class="hero-text">
+        <h1 class="hero-name">Alain Okou</h1>
+        <p class="hero-subtitle">Seattle Photographer · Film &amp; Digital</p>
+      </div>
     </div>
-  </div>
+  </section>
+
+  <hr class="divider" />
+
+  <!-- Bio -->
+  <section class="bio">
+    <div class="bio-inner">
+      <div class="bio-pull">
+        <blockquote class="pull-quote">
+          "I try best to capture feelings and essence through the images I take, to invoke some sort of emotion in the viewer."
+        </blockquote>
+      </div>
+
+      <div class="bio-body">
+        <p>
+          Alain is a photographer with a love for visual storytelling.
+          Originally from New Jersey and now based in Seattle, he brings four years of photographic experience to his work,
+          including three years immersed in the art of film.
+          Whether in vivid color or classic black and white, he seeks to capture a collection of awe-inspiring images.
+        </p>
+        <p>
+          It's because of this that he has a hard time categorizing his work — it's more a collection of moments.
+          He finds joy in being able to see the changes in what caught his eye, and in bringing back memories of what
+          exactly it was that excited him. Hopefully, through this, you'll be excited to see what he's been up to.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="divider" />
+
   <Footer />
 </div>
 
 <style>
-  .about-container {
+  /* ── Page shell ── */
+  .about-page {
     min-height: 100vh;
-    width: 100%;
-    background-color: var(--bg-color);
-    color: var(--text-color);
+    background-color: #0e0e0e;
+    color: #f0ebe3;
     display: flex;
     flex-direction: column;
   }
 
-  .about-content {
-    flex: 1;
+  /* ── Dividers ── */
+  .divider {
+    border: none;
+    border-top: 1px solid rgba(200, 192, 184, 0.08);
+    margin: 0;
+  }
+
+  /* ── Hero ── */
+  .hero {
+    min-height: 65vh;
     display: flex;
-    flex-direction: column;
-    justify-content: center;
     align-items: center;
-    text-align: center;
-    padding: 4rem 2rem;
-    max-width: 800px;
+    padding: 6rem 5vw 4rem;
+  }
+
+  .hero-inner {
+    display: flex;
+    align-items: center;
+    gap: 5rem;
+    max-width: 1100px;
     margin: 0 auto;
-  }
-  
-  .quote {
-    background-color: color-mix(in srgb, var(--secondary-color) 30%, white);
-    color: color-mix(in srgb, var(--secondary-color) 80%, black);
-    border: 1px solid var(--secondary-color);
-    border-radius: 10px;
-    padding: 1rem;
-    margin: 1rem 0;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  }
-
-  .profile-photo {
-    width: 250px;
-    height: 250px;
-    border-radius: 50%;
-    object-fit: cover;
-    margin-bottom: 2rem;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  }
-
-  .text-content {
     width: 100%;
   }
 
-  h1 {
-    font-size: 3rem;
-    font-weight: 300;
-    margin: 0 0 2rem 0;
+  .hero-image-wrap {
+    flex: 0 0 auto;
   }
 
-  p {
-    font-size: 1.2rem;
-    line-height: 1.6;
-    margin: 1rem 0;
-    opacity: 0.9;
+  .hero-img {
+    width: 420px;
+    height: 520px;
+    object-fit: cover;
+    display: block;
+    filter: sepia(8%) contrast(1.04);
+  }
+
+  .hero-text {
+    flex: 1;
+  }
+
+  .hero-name {
+    font-family: var(--font-display, 'Cormorant Garamond', Georgia, serif);
+    font-weight: 300;
+    font-size: clamp(3rem, 5vw, 5rem);
+    line-height: 1.05;
+    margin: 0 0 1.25rem 0;
+    color: #f0ebe3;
+    letter-spacing: -0.01em;
+  }
+
+  .hero-subtitle {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 100;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.35em;
+    color: rgba(200, 192, 184, 0.55);
+    margin: 0;
+  }
+
+  /* ── Bio ── */
+  .bio {
+    padding: 5rem 5vw;
+  }
+
+  .bio-inner {
+    display: grid;
+    grid-template-columns: 1fr 1.4fr;
+    gap: 5rem;
+    max-width: 1100px;
+    margin: 0 auto;
+    align-items: start;
+  }
+
+  .pull-quote {
+    font-family: var(--font-display, 'Cormorant Garamond', Georgia, serif);
+    font-weight: 300;
+    font-style: italic;
+    font-size: clamp(1.5rem, 2.2vw, 2.1rem);
+    line-height: 1.45;
+    color: #b8936a;
+    margin: 0;
+    padding: 0;
+    border: none;
+  }
+
+  .bio-body p {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 300;
+    font-size: 13px;
+    line-height: 1.9;
+    color: #c8c0b8;
+    margin: 0 0 1.4em 0;
+  }
+
+  .bio-body p:last-child {
+    margin-bottom: 0;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 900px) {
+    .bio-inner {
+      grid-template-columns: 1fr;
+      gap: 2.5rem;
+    }
   }
 
   @media (max-width: 768px) {
-    .about-content {
-      padding: 6rem 1rem 2rem;
+    .hero {
+      padding: 5rem 1.5rem 3rem;
+      min-height: unset;
     }
 
-    .profile-photo {
-      width: 200px;
-      height: 200px;
-      margin-bottom: 1.5rem;
+    .hero-inner {
+      flex-direction: column;
+      align-items: center;
+      gap: 2.5rem;
+      text-align: center;
     }
 
-    h1 {
-      font-size: 2rem;
-      margin-bottom: 1.5rem;
+    .hero-img {
+      width: 100%;
+      max-width: 340px;
+      height: 380px;
     }
 
-    p {
-      font-size: 1rem;
-      line-height: 1.5;
+    .hero-name {
+      font-size: 2.8rem;
+    }
+
+    .bio {
+      padding: 3rem 1.5rem;
     }
   }
 
   @media (max-width: 480px) {
-    .profile-photo {
-      width: 150px;
-      height: 150px;
-      margin-bottom: 1rem;
+    .hero-img {
+      max-width: 280px;
+      height: 320px;
     }
 
-    h1 {
-      font-size: 1.75rem;
-      margin-bottom: 1rem;
+    .hero-name {
+      font-size: 2.2rem;
     }
   }
-</style> 
+</style>

--- a/src/routes/prints/+page.svelte
+++ b/src/routes/prints/+page.svelte
@@ -30,168 +30,175 @@
 
 </script>
 
-<div class="page-container" style="--bg-color: {theme.background.light}; --text-color: {theme.text.primary};">
-  <Navbar 
-    backgroundColor={theme.text.primary}
-    textColor={theme.background.light}
-  />
-  <div class="content-area">
-    <!-- Image Container with aspect ratio -->
-    <div 
+<div class="prints-page">
+  <Navbar />
+
+  <!-- Page header -->
+  <header class="page-header">
+    <h1 class="page-title">Prints &amp; Collabs</h1>
+    <p class="page-subtitle">Original photography · Limited editions</p>
+  </header>
+
+  <hr class="divider" />
+
+  <!-- Main image -->
+  <section class="image-section">
+    <div
       class="image-container"
       style:aspect-ratio={data.width && data.height ? `${data.width} / ${data.height}` : '16 / 9'}
     >
       {#if !imageError}
-        <img 
+        <img
           bind:this={imgElement}
-          src={primaryImageSrc} 
-          alt="Selection of photographic prints" 
+          src={primaryImageSrc}
+          width={data.width}
+          height={data.height}
+          alt="Selection of photographic prints"
           class="prints-image"
           class:loaded={imageLoaded}
-          on:load={() => { imageLoaded = true; }}
-          on:error={() => {
+          onload={() => { imageLoaded = true; }}
+          onerror={() => {
             console.error('Primary prints image failed to load, trying fallback');
             imageError = true;
-            imageLoaded = false; // Reset load state for fallback
+            imageLoaded = false;
           }}
         />
       {:else}
-        <!-- Fallback image attempt -->
-        <img 
+        <img
           bind:this={imgElement}
           src={fallbackImageSrc}
-          alt="Selection of photographic prints (fallback)" 
+          width={data.width}
+          height={data.height}
+          alt="Selection of photographic prints (fallback)"
           class="prints-image"
           class:loaded={imageLoaded}
-          on:load={() => { imageLoaded = true; }}
-          on:error={() => {
+          onload={() => { imageLoaded = true; }}
+          onerror={() => {
             console.error('Fallback prints image also failed to load.');
-            // Keep imageError true
           }}
         />
       {/if}
       {#if imageError && !imageLoaded}
-        <!-- Optional: Display text if both fail -->
         <div class="error-placeholder">Image unavailable</div>
       {/if}
     </div>
+  </section>
 
-    <div class="section">
-      <p>
-        I have a selection of prints available <a href="https://aokframes.darkroom.com" target="_blank" rel="noopener noreferrer">here</a>.
+  <hr class="divider" />
+
+  <!-- Description / CTA -->
+  <section class="cta-section">
+    <div class="cta-inner">
+      <p class="cta-text">
+        A selection of prints is available through my online store. Each print is produced to order,
+        ensuring the highest quality on archival paper.
+        For professional inquiries, collaborations, or to commission a custom piece, reach out directly.
       </p>
+
+      <div class="cta-links">
+        <a
+          href="https://aokframes.darkroom.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn-bordered"
+        >
+          View Store
+        </a>
+        <a href="mailto:aokframes@gmail.com" class="btn-bordered">
+          Get in Touch
+        </a>
+      </div>
+
+      <!-- Featured work -->
+      <div class="featured">
+        <h2 class="featured-title">Featured Work</h2>
+        <ul class="featured-list">
+          <li>
+            <a
+              href="https://www.ephemere.tokyo/store/p/anarchy2"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Ephemere Anarchy2
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="section">
-      <p>
-        For professional inquiries, collaborations, or to commission a unique custom print, please feel free to contact me at <a href="mailto:aokframes@gmail.com">aokframes@gmail.com</a>. I look forward to hearing from you!
-      </p>
-    </div>
-    <div class="section">
-      <h1>Featured work</h1>
-      <p>
-        Currently featured works are:
-      </p>
-      <ul>
-        <li><a href="https://www.ephemere.tokyo/store/p/anarchy2">Ephemere Anarchy2</a></li>
-      </ul>
-    </div>
-  </div>
+  </section>
+
   <Footer />
 </div>
 
 <style>
-  .page-container {
+  /* ── Page shell ── */
+  .prints-page {
     min-height: 100vh;
-    width: 100%;
-    background-color: var(--bg-color);
-    color: var(--text-color);
+    background-color: #0e0e0e;
+    color: #f0ebe3;
     display: flex;
     flex-direction: column;
   }
 
-  .content-area {
-    flex: 1; /* Takes up remaining space */
-    display: flex;
-    flex-direction: column;
-    justify-content: center; /* Center vertically */
-    align-items: center; /* Center horizontally */
+  /* ── Dividers ── */
+  .divider {
+    border: none;
+    border-top: 1px solid rgba(200, 192, 184, 0.08);
+    margin: 0;
+  }
+
+  /* ── Page header ── */
+  .page-header {
+    padding: 6rem 5vw 3rem;
     text-align: center;
-    padding: 2rem;
-    gap: 1.5rem; /* Adjusted gap between sections */
   }
-  
-  .section {
+
+  .page-title {
+    font-family: var(--font-display, 'Cormorant Garamond', Georgia, serif);
+    font-weight: 300;
+    font-size: clamp(3rem, 5.5vw, 6rem);
+    line-height: 1;
+    margin: 0 0 1rem 0;
+    color: #f0ebe3;
+    letter-spacing: -0.01em;
+  }
+
+  .page-subtitle {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 100;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.35em;
+    color: rgba(200, 192, 184, 0.45);
+    margin: 0;
+  }
+
+  /* ── Image section ── */
+  .image-section {
+    padding: 4rem 5vw;
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    max-width: 600px; /* Limit width for readability */
+    justify-content: center;
   }
 
-  p {
-    font-size: 1.2rem; /* Adjust size as needed */
-    line-height: 1.6;
-    margin: 0;
-  }
-
-  h1 {
-    font-size: 2rem;
-    line-height: 1.6;
-    margin: 0;
-  }
-
-  a {
-    color: color-mix(in srgb, var(--text-color) 85%, black); /* Link color */
-    text-decoration: underline;
-  }
-
-  a:hover {
-    opacity: 0.8;
-  }
-
-  @media (max-width: 768px) {
-    p {
-      font-size: 1rem;
-    }
-    .content-area {
-      padding-top: 6rem;
-    }
-  }
-
-  /* Styles for image container and image */
   .image-container {
     display: block;
-    width: 600px; /* Max width matches existing style */
-    max-width: 100%;
+    width: 100%;
+    max-width: 900px;
     position: relative;
-    background-color: #f0f0f0; /* Placeholder color */
-    background-image: url('/images/constants/placeholder.svg'); /* Use same placeholder */
-    background-size: cover;
-    background-position: center;
-    margin: 0 auto 2rem auto; /* Center horizontally, add bottom margin */
-    border-radius: 8px; /* Optional: Add slight rounded corners */
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Optional: Add subtle shadow */
-    overflow: hidden; /* Needed to contain absolute positioned image */
+    background-color: #1a1a1a;
+    overflow: hidden;
   }
 
   .prints-image {
-    /* Position absolutely within container */
     position: absolute;
     top: 0;
     left: 0;
-    width: 100%; 
-    height: 100%; 
-    object-fit: cover; /* Cover the container */
-    display: block; 
-    /* Fade-in transition */
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
     opacity: 0;
-    transition: opacity 0.5s ease-in-out;
-    /* Remove conflicting styles that are now on container */
-    /* max-width: 100%; */
-    /* width: 600px; */
-    /* height: auto; */
-    /* margin: 0 auto 2rem auto; */
-    /* border-radius: 8px; */
-    /* box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); */
+    transition: opacity 0.6s ease-in-out;
   }
 
   .prints-image.loaded {
@@ -199,16 +206,139 @@
   }
 
   .error-placeholder {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: rgba(0,0,0,0.5);
-      font-size: 1rem;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 300;
+    font-size: 0.85rem;
+    letter-spacing: 0.1em;
+    color: rgba(200, 192, 184, 0.35);
   }
 
-</style> 
+  /* ── CTA section ── */
+  .cta-section {
+    padding: 4rem 5vw 5rem;
+  }
+
+  .cta-inner {
+    max-width: 680px;
+    margin: 0 auto;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2.5rem;
+  }
+
+  .cta-text {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 300;
+    font-size: 13px;
+    line-height: 1.9;
+    color: #c8c0b8;
+    margin: 0;
+  }
+
+  .cta-links {
+    display: flex;
+    gap: 1.25rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .btn-bordered {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 400;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.25em;
+    color: #b8936a;
+    border: 1px solid #b8936a;
+    padding: 0.75rem 2rem;
+    text-decoration: none;
+    display: inline-block;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .btn-bordered:hover {
+    background-color: #b8936a;
+    color: #0e0e0e;
+  }
+
+  /* ── Featured work ── */
+  .featured {
+    width: 100%;
+    text-align: center;
+  }
+
+  .featured-title {
+    font-family: var(--font-display, 'Cormorant Garamond', Georgia, serif);
+    font-weight: 300;
+    font-size: 1.6rem;
+    color: #f0ebe3;
+    margin: 0 0 1rem 0;
+  }
+
+  .featured-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .featured-list li {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 300;
+    font-size: 13px;
+    color: #c8c0b8;
+    margin-bottom: 0.5rem;
+  }
+
+  .featured-list a {
+    color: #c8c0b8;
+    text-decoration: none;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid rgba(200, 192, 184, 0.2);
+    transition: color 0.2s, border-color 0.2s;
+  }
+
+  .featured-list a:hover {
+    color: #b8936a;
+    border-color: #b8936a;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 768px) {
+    .page-header {
+      padding: 5rem 1.5rem 2.5rem;
+    }
+
+    .page-title {
+      font-size: clamp(2.5rem, 10vw, 3.5rem);
+    }
+
+    .image-section {
+      padding: 2.5rem 1.5rem;
+    }
+
+    .cta-section {
+      padding: 3rem 1.5rem 4rem;
+    }
+
+    .cta-links {
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .btn-bordered {
+      width: 100%;
+      max-width: 260px;
+      text-align: center;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- `about/+page.svelte`: Darkroom rewrite — profile image (420×520) side-by-side with name/subtitle, two-column bio grid (pull quote in gold italic Cormorant, paragraphs in Josefin Sans), responsive stacking below 768px
- `prints/+page.svelte`: script block preserved verbatim (`data.width`/`data.height`, image loading state); new page header in Cormorant, image section up to 900px wide, gold-bordered CTA buttons

## Test plan
- [ ] About page shows profile image beside name in Cormorant Garamond
- [ ] Pull quote renders in gold italic on desktop; stacks on mobile
- [ ] Prints page displays image at correct aspect ratio using server-provided dimensions
- [ ] "View Store" and "Get in Touch" buttons have gold border, fill on hover
- [ ] No data layer files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
