### PR TITLE
Sprint 1: Quick-Peek route, data layer, and navbar link

### DIFF
--- a/src/lib/components/peek/FilmStrip.svelte
+++ b/src/lib/components/peek/FilmStrip.svelte
@@ -21,6 +21,20 @@
   const doubled = $derived(ghost ? [] : [...images, ...images]);
   const frameCount = $derived(ghost ? GHOST_FRAMES * 2 : doubled.length);
   const perfHoles = $derived(Array(HOLES_PER_FRAME * frameCount).fill(0));
+
+  // Track loaded state per frame — resets whenever the image list changes
+  let imgLoaded = $state<boolean[]>([]);
+
+  $effect(() => {
+    imgLoaded = new Array(doubled.length).fill(false);
+  });
+
+  // Svelte action — catches images that are already cached (complete before onload fires)
+  function checkLoaded(node: HTMLImageElement, idx: number) {
+    if (node.complete && node.naturalHeight > 0) {
+      imgLoaded[idx] = true;
+    }
+  }
 </script>
 
 <section class="strip-section">
@@ -50,10 +64,15 @@
         {:else}
           {#each doubled as image, i}
             <div class="film-frame" style="height: {height}px;">
+              <div class="frame-shimmer" class:shimmer-done={imgLoaded[i]}></div>
               <img
                 src={image.url}
                 alt=""
                 loading={i < 4 ? 'eager' : 'lazy'}
+                class:img-loaded={imgLoaded[i]}
+                use:checkLoaded={i}
+                onload={() => { imgLoaded[i] = true; }}
+                onerror={() => { imgLoaded[i] = true; }}
               />
               <span class="frame-num">{String((i % images.length) + 1).padStart(2, '0')}</span>
             </div>
@@ -108,14 +127,49 @@
     background: #111;
   }
 
+  /* Shimmer placeholder — sits above the dark frame bg, below the grain */
+  .frame-shimmer {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    background: linear-gradient(
+      90deg,
+      #141414 0%,
+      #1e1e1e 40%,
+      #252525 50%,
+      #1e1e1e 60%,
+      #141414 100%
+    );
+    background-size: 200% 100%;
+    animation: shimmer-sweep 1.6s ease-in-out infinite;
+    transition: opacity 0.5s ease;
+    pointer-events: none;
+  }
+
+  .frame-shimmer.shimmer-done {
+    opacity: 0;
+  }
+
+  @keyframes shimmer-sweep {
+    0%   { background-position: 150% 0; }
+    100% { background-position: -150% 0; }
+  }
+
   .film-frame img {
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
     object-fit: cover;
     display: block;
     filter: sepia(6%) contrast(1.05);
-    transition: filter 0.4s ease;
+    opacity: 0;
+    transition: opacity 0.5s ease, filter 0.4s ease;
     pointer-events: none;
+  }
+
+  .film-frame img.img-loaded {
+    opacity: 1;
   }
 
   .strip-inner:hover .film-frame:hover img {

--- a/src/lib/components/peek/FilmStrip.svelte
+++ b/src/lib/components/peek/FilmStrip.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+  import type { PeekImage } from '$lib/types/peek';
+
+  let {
+    images = [],
+    ghost = false,
+    direction = 'forward',
+    speed = 40,
+    height = 260
+  }: {
+    images: PeekImage[];
+    ghost?: boolean;
+    direction?: 'forward' | 'reverse';
+    speed?: number;
+    height?: number;
+  } = $props();
+
+  const HOLES_PER_FRAME = 17;
+  const GHOST_FRAMES = 12;
+
+  const doubled = $derived(ghost ? [] : [...images, ...images]);
+  const frameCount = $derived(ghost ? GHOST_FRAMES * 2 : doubled.length);
+  const perfHoles = $derived(Array(HOLES_PER_FRAME * frameCount).fill(0));
+</script>
+
+<section class="strip-section">
+  <div class="strip-track">
+    <div class="strip-fade-left"></div>
+    <div class="strip-fade-right"></div>
+    <div
+      class="strip-inner"
+      style="animation-duration: {speed}s; animation-direction: {direction === 'reverse' ? 'reverse' : 'normal'};"
+    >
+      <!-- Top perf row -->
+      <div class="perf-row">
+        {#each perfHoles as _}
+          <span class="perf-hole"></span>
+        {/each}
+      </div>
+
+      <!-- Frames -->
+      <div class="frames-row">
+        {#if ghost}
+          {#each Array(GHOST_FRAMES * 2) as _, i}
+            <div class="film-frame ghost-frame" style="height: {height}px;">
+              <div class="ghost-panel"></div>
+              <span class="frame-num">{String((i % GHOST_FRAMES) + 1).padStart(2, '0')}</span>
+            </div>
+          {/each}
+        {:else}
+          {#each doubled as image, i}
+            <div class="film-frame" style="height: {height}px;">
+              <img
+                src={image.url}
+                alt=""
+                loading={i < 4 ? 'eager' : 'lazy'}
+              />
+              <span class="frame-num">{String((i % images.length) + 1).padStart(2, '0')}</span>
+            </div>
+          {/each}
+        {/if}
+      </div>
+
+      <!-- Bottom perf row -->
+      <div class="perf-row">
+        {#each perfHoles as _}
+          <span class="perf-hole"></span>
+        {/each}
+      </div>
+    </div>
+  </div>
+</section>
+
+<style>
+  .strip-section {
+    padding: 2rem 0;
+    position: relative;
+  }
+
+  .strip-track {
+    position: relative;
+    overflow: hidden;
+    background: #080808;
+  }
+
+  .strip-inner {
+    display: inline-flex;
+    flex-direction: column;
+    animation: scroll-strip linear infinite;
+    will-change: transform;
+  }
+
+  .strip-inner:hover {
+    animation-play-state: paused;
+  }
+
+  .frames-row {
+    display: flex;
+    align-items: stretch;
+  }
+
+  .film-frame {
+    position: relative;
+    width: 340px;
+    flex-shrink: 0;
+    overflow: hidden;
+    border-right: 1px solid rgba(200, 192, 184, 0.04);
+    background: #111;
+  }
+
+  .film-frame img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    filter: sepia(6%) contrast(1.05);
+    transition: filter 0.4s ease;
+    pointer-events: none;
+  }
+
+  .strip-inner:hover .film-frame:hover img {
+    filter: sepia(0%) contrast(1.1);
+  }
+
+  .ghost-frame .ghost-panel {
+    width: 100%;
+    height: 100%;
+    border: 1px solid rgba(200, 192, 184, 0.07);
+    background: transparent;
+  }
+
+  .frame-num {
+    position: absolute;
+    bottom: 8px;
+    left: 10px;
+    font-family: var(--font-ui);
+    font-size: 8px;
+    font-weight: 300;
+    letter-spacing: 0.25em;
+    color: rgba(200, 192, 184, 0.4);
+    pointer-events: none;
+    z-index: 2;
+  }
+
+  /* Grain overlay */
+  .film-frame::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.04'/%3E%3C/svg%3E");
+    opacity: 0.35;
+    pointer-events: none;
+    mix-blend-mode: overlay;
+    z-index: 1;
+  }
+
+  /* Perf rows */
+  .perf-row {
+    display: flex;
+    align-items: center;
+    height: 20px;
+    background: #050505;
+    flex-shrink: 0;
+  }
+
+  .perf-hole {
+    display: inline-block;
+    width: 12px;
+    height: 14px;
+    border: 1px solid rgba(200, 192, 184, 0.22);
+    border-radius: 2px;
+    flex-shrink: 0;
+    background: #0e0e0e;
+    margin: 0 8px 0 0;
+  }
+
+  /* Fade edges */
+  .strip-fade-left,
+  .strip-fade-right {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 120px;
+    z-index: 10;
+    pointer-events: none;
+  }
+
+  .strip-fade-left {
+    left: 0;
+    background: linear-gradient(to right, var(--near-black), transparent);
+  }
+
+  .strip-fade-right {
+    right: 0;
+    background: linear-gradient(to left, var(--near-black), transparent);
+  }
+
+  @keyframes scroll-strip {
+    0%   { transform: translateX(0); }
+    100% { transform: translateX(-50%); }
+  }
+</style>

--- a/src/lib/components/ui/navbar.svelte
+++ b/src/lib/components/ui/navbar.svelte
@@ -68,6 +68,9 @@
         <a href="/about" class:active={currentPath.startsWith('/about')}>About</a>
       </li>
       <li>
+        <a href="/peek" class:active={currentPath.startsWith('/peek')}>Peek</a>
+      </li>
+      <li>
         <a href="/blog" class:active={currentPath.startsWith('/blog')}>Blog</a>
       </li>
       <li>
@@ -100,6 +103,9 @@
       </li>
       <li>
         <a href="/about" onclick={closeMenu} class:active={currentPath.startsWith('/about')}>About</a>
+      </li>
+      <li>
+        <a href="/peek" onclick={closeMenu} class:active={currentPath.startsWith('/peek')}>Peek</a>
       </li>
       <li>
         <a href="/blog" onclick={closeMenu} class:active={currentPath.startsWith('/blog')}>Blog</a>

--- a/src/lib/types/peek.ts
+++ b/src/lib/types/peek.ts
@@ -1,0 +1,10 @@
+export type PeekImage = {
+  key: string;       // "temps/shot-001.webp"
+  url: string;       // full CDN URL
+  uploaded: string;  // ISO date string
+};
+
+export type PeekPageData = {
+  images: PeekImage[];
+  isEmpty: boolean;
+};

--- a/src/routes/peek/+page.server.ts
+++ b/src/routes/peek/+page.server.ts
@@ -1,0 +1,26 @@
+import type { PageServerLoad } from './$types';
+import { assetUrl } from '$lib/utils/r2';
+import type { PeekImage } from '$lib/types/peek';
+
+export const load: PageServerLoad = async ({ platform }) => {
+  try {
+    const r2 = (platform as any)?.env?.R2_BUCKET;
+    if (!r2) return { images: [], isEmpty: true };
+
+    const listed = await r2.list({ prefix: 'temps/', limit: 500 });
+    const imageExts = /\.(webp|jpe?g|png)$/i;
+
+    const images: PeekImage[] = (listed.objects ?? [])
+      .filter((obj: any) => imageExts.test(obj.key))
+      .sort((a: any, b: any) => new Date(b.uploaded).getTime() - new Date(a.uploaded).getTime())
+      .map((obj: any) => ({
+        key: obj.key,
+        url: assetUrl(obj.key),
+        uploaded: new Date(obj.uploaded).toISOString(),
+      }));
+
+    return { images, isEmpty: images.length === 0 };
+  } catch {
+    return { images: [], isEmpty: true };
+  }
+};

--- a/src/routes/peek/+page.svelte
+++ b/src/routes/peek/+page.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
   import Navbar from '$lib/components/ui/navbar.svelte';
   import Footer from '$lib/components/ui/footer.svelte';
+  import FilmStrip from '$lib/components/peek/FilmStrip.svelte';
   import type { PageData } from './$types';
 
-  const { data }: { data: PageData } = $props();
+  let { data }: { data: PageData } = $props();
+
+  const strip1 = $derived(data.images.filter((_: unknown, i: number) => i % 2 === 0));
+  const strip2 = $derived(data.images.filter((_: unknown, i: number) => i % 2 !== 0));
 </script>
 
 <div class="peek-page">
@@ -20,7 +24,24 @@
       </p>
     </header>
 
-    <div class="strips-placeholder">Film strips load here — Sprint 2</div>
+    {#if data.isEmpty}
+      <p class="holding-msg">
+        I got nothing right now, but I promise I'm working on the next batch. Maybe. Kinda.
+      </p>
+      <FilmStrip images={[]} ghost={true} direction="forward" speed={40} height={260} />
+      <FilmStrip images={[]} ghost={true} direction="reverse" speed={55} height={200} />
+    {:else}
+      <FilmStrip images={strip1} direction="forward" speed={40} height={260} />
+      <FilmStrip images={strip2} direction="reverse" speed={55} height={200} />
+    {/if}
+
+    <div class="bottom-meta">
+      <div>
+        <p class="bottom-meta-label">Hover to pause</p>
+        <p class="hover-hint">← Auto-scrolling filmstrip →</p>
+      </div>
+      <div class="bottom-meta-count">{data.images.length}</div>
+    </div>
   </main>
 
   <Footer />
@@ -76,13 +97,47 @@
     white-space: nowrap;
   }
 
-  .strips-placeholder {
-    padding: 4rem 0;
+  .holding-msg {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-weight: 300;
+    font-size: clamp(1rem, 1.8vw, 1.4rem);
+    color: rgba(200, 192, 184, 0.4);
     text-align: center;
-    font-family: var(--font-ui);
+    padding: 2.5rem 0 3rem;
+    letter-spacing: 0.02em;
+  }
+
+  .bottom-meta {
+    padding: 2rem 5vw 4rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    border-top: 1px solid rgba(200, 192, 184, 0.06);
+  }
+
+  .bottom-meta-label {
     font-size: 9px;
     letter-spacing: 0.3em;
     text-transform: uppercase;
-    color: rgba(200, 192, 184, 0.2);
+    color: rgba(200, 192, 184, 0.35);
+  }
+
+  .hover-hint {
+    font-size: 9px;
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+    color: var(--green-light);
+    opacity: 0.6;
+    margin-top: 0.5rem;
+  }
+
+  .bottom-meta-count {
+    font-family: var(--font-display);
+    font-size: 4rem;
+    font-weight: 300;
+    font-style: italic;
+    color: rgba(200, 192, 184, 0.08);
+    line-height: 1;
   }
 </style>

--- a/src/routes/peek/+page.svelte
+++ b/src/routes/peek/+page.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import Navbar from '$lib/components/ui/navbar.svelte';
+  import Footer from '$lib/components/ui/footer.svelte';
+  import type { PageData } from './$types';
+
+  const { data }: { data: PageData } = $props();
+</script>
+
+<div class="peek-page">
+  <Navbar />
+
+  <main class="peek-main">
+    <header class="peek-header">
+      <p class="peek-eyebrow">Quick-Peek</p>
+      <h1 class="peek-title">On the Table</h1>
+      <p class="peek-desc">
+        Images I've processed in the past days, just a peek into what I'm up to.<br />
+        Images will either be made into a work, or stored away, archived.<br />
+        Check back to see what's on the table.
+      </p>
+    </header>
+
+    <div class="strips-placeholder">Film strips load here — Sprint 2</div>
+  </main>
+
+  <Footer />
+</div>
+
+<style>
+  .peek-page {
+    min-height: 100vh;
+    background-color: var(--near-black);
+    color: var(--warm-white);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .peek-main {
+    flex: 1;
+    padding-bottom: 5rem;
+  }
+
+  .peek-header {
+    padding: 9rem 5vw 3rem;
+    border-bottom: 1px solid rgba(200, 192, 184, 0.08);
+    text-align: center;
+  }
+
+  .peek-eyebrow {
+    font-family: var(--font-ui);
+    font-size: 8px;
+    font-weight: 300;
+    letter-spacing: 0.45em;
+    text-transform: uppercase;
+    color: var(--green-light);
+    margin-bottom: 1rem;
+  }
+
+  .peek-title {
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 6vw, 6rem);
+    font-weight: 300;
+    font-style: italic;
+    line-height: 1;
+    letter-spacing: -0.01em;
+    margin-bottom: 1.5rem;
+  }
+
+  .peek-desc {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    font-weight: 300;
+    letter-spacing: 0.15em;
+    line-height: 2;
+    color: rgba(200, 192, 184, 0.85);
+    white-space: nowrap;
+  }
+
+  .strips-placeholder {
+    padding: 4rem 0;
+    text-align: center;
+    font-family: var(--font-ui);
+    font-size: 9px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: rgba(200, 192, 184, 0.2);
+  }
+</style>

--- a/workers/peek-purge/README.md
+++ b/workers/peek-purge/README.md
@@ -1,0 +1,51 @@
+# peek-purge
+
+Cloudflare Worker that automatically deletes images from the `temps/` R2 prefix older than 14 days.
+
+## How it works
+
+- Runs daily via cron at **3 AM UTC**
+- Lists all objects under `temps/` in R2 (paginated, handles any count)
+- Deletes any object whose `uploaded` timestamp is older than 14 days
+- Logs each deletion to Cloudflare Worker logs
+
+## Deploy
+
+```bash
+cd workers/peek-purge
+npx wrangler deploy
+```
+
+## Manual trigger / dry-run
+
+Trigger a live run:
+```bash
+curl -X POST https://aokframes-peek-purge.<your-subdomain>.workers.dev
+```
+
+Dry-run (logs what would be deleted without actually deleting):
+```bash
+curl -X POST https://aokframes-peek-purge.<your-subdomain>.workers.dev \
+  -H "Content-Type: application/json" \
+  -d '{"dryRun": true}'
+```
+
+Response:
+```json
+{
+  "scanned": 22,
+  "deleted": 5,
+  "errors": [],
+  "cutoff": "2026-05-07T03:00:00.000Z",
+  "dryRun": true
+}
+```
+
+## Configuration
+
+| Setting | Value |
+|---|---|
+| R2 bucket | `aokframes-website-assets` |
+| Prefix scanned | `temps/` |
+| Retention window | 14 days |
+| Cron | `0 3 * * *` (3 AM UTC daily) |

--- a/workers/peek-purge/index.js
+++ b/workers/peek-purge/index.js
@@ -1,0 +1,101 @@
+/**
+ * peek-purge — Cloudflare Worker
+ *
+ * Runs daily at 3 AM UTC. Deletes any object under the `temps/` prefix
+ * in R2 that was uploaded more than 14 days ago.
+ *
+ * Deploy:
+ *   cd workers/peek-purge
+ *   npx wrangler deploy
+ *
+ * Test locally (dry-run flag):
+ *   POST /trigger  { "dryRun": true }
+ */
+
+const TWO_WEEKS_MS = 14 * 24 * 60 * 60 * 1000;
+
+async function purge(env, dryRun = false) {
+  const cutoff = new Date(Date.now() - TWO_WEEKS_MS);
+  console.log(`[peek-purge] cutoff: ${cutoff.toISOString()} | dryRun: ${dryRun}`);
+
+  let cursor;
+  let scanned = 0;
+  let deleted = 0;
+  const errors = [];
+
+  do {
+    const listed = await env.R2_BUCKET.list({
+      prefix: 'temps/',
+      cursor,
+      limit: 500,
+    });
+
+    for (const obj of listed.objects) {
+      scanned++;
+      const age = new Date(obj.uploaded);
+
+      if (age < cutoff) {
+        if (!dryRun) {
+          try {
+            await env.R2_BUCKET.delete(obj.key);
+            deleted++;
+            console.log(`[peek-purge] deleted: ${obj.key} (uploaded ${age.toISOString()})`);
+          } catch (err) {
+            errors.push({ key: obj.key, error: err.message });
+            console.error(`[peek-purge] failed to delete ${obj.key}: ${err.message}`);
+          }
+        } else {
+          deleted++;
+          console.log(`[peek-purge] dry-run would delete: ${obj.key} (uploaded ${age.toISOString()})`);
+        }
+      }
+    }
+
+    cursor = listed.truncated ? listed.cursor : undefined;
+  } while (cursor);
+
+  return { scanned, deleted, errors, cutoff: cutoff.toISOString(), dryRun };
+}
+
+export default {
+  // Cron trigger — runs on schedule
+  async scheduled(_event, env, _ctx) {
+    const result = await purge(env, false);
+    console.log(
+      `[peek-purge] done — scanned: ${result.scanned}, deleted: ${result.deleted}, errors: ${result.errors.length}`
+    );
+  },
+
+  // HTTP handler — allows manual trigger + dry-run from Cloudflare dashboard or curl
+  async fetch(request, env, _ctx) {
+    if (request.method !== 'POST') {
+      return new Response(
+        JSON.stringify({
+          status: 'ready',
+          message: 'POST to /trigger to run manually. Add { "dryRun": true } to preview without deleting.',
+        }),
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    let dryRun = false;
+    try {
+      const body = await request.json();
+      dryRun = body?.dryRun === true;
+    } catch {
+      // no body or invalid JSON — that's fine, default to live run
+    }
+
+    try {
+      const result = await purge(env, dryRun);
+      return new Response(JSON.stringify(result, null, 2), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      return new Response(JSON.stringify({ error: err.message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  },
+};

--- a/workers/peek-purge/wrangler.toml
+++ b/workers/peek-purge/wrangler.toml
@@ -1,0 +1,12 @@
+name = "aokframes-peek-purge"
+main = "index.js"
+compatibility_date = "2024-04-04"
+
+[[r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "aokframes-website-assets"
+preview_bucket_name = "aokframes-website-assets"
+
+# Runs daily at 3 AM UTC
+[triggers]
+crons = ["0 3 * * *"]


### PR DESCRIPTION
- Install gsap@3.15.0 and @fontsource/cormorant-garamond
- Update theme.ts with Darkroom palette; keep legacy aliases for server compat
- Rewrite app.css: Darkroom CSS custom props, dark defaults, film-grain overlay, reduced-motion override
- Create src/lib/utils/animations.ts: GSAP helpers, all SSR-guarded
- app.html: theme-color meta, font preconnect hints

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>- Add PeekImage + PeekPageData types (src/lib/types/peek.ts)
- Add +page.server.ts: lists temps/ from R2, sorts newest-first, graceful empty/error fallback
- Add +page.svelte: page shell with finalized header copy and CSS, strips placeholder
- Add Peek nav link to navbar (desktop + mobile) between About and Blog

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>