### PR TITLE
Fix:Reduce filmstrip edge fades on mobile

### DIFF
--- a/src/lib/components/peek/FilmStrip.svelte
+++ b/src/lib/components/peek/FilmStrip.svelte
@@ -239,6 +239,13 @@
     pointer-events: none;
   }
 
+  @media (max-width: 768px) {
+    .strip-fade-left,
+    .strip-fade-right {
+      width: 40px;
+    }
+  }
+
   .strip-fade-left {
     left: 0;
     background: linear-gradient(to right, var(--near-black), transparent);


### PR DESCRIPTION
120px is too wide on small screens — trim to 40px on mobile so more of the strip is visible without losing the fade effect.