### PR TITLE
Lightbox nav + swipe, peek CSS fix, per-page titles

### DIFF
--- a/src/lib/components/blog/BlogPost.svelte
+++ b/src/lib/components/blog/BlogPost.svelte
@@ -3,6 +3,13 @@
 
   let { post }: { post: BlogPost } = $props();
 
+  let imgLoaded = $state(false);
+
+  // Catches images already in the browser cache (complete before onload fires)
+  function checkLoaded(node: HTMLImageElement) {
+    if (node.complete && node.naturalHeight > 0) imgLoaded = true;
+  }
+
   function formatDate(dateStr: string): string {
     try {
       return new Date(dateStr).toLocaleDateString('en-US', {
@@ -19,11 +26,16 @@
 <a href="/blog/{encodeURIComponent(post.id)}" class="post-card" aria-label={post.title}>
   {#if post.image}
     <div class="card-image-wrap">
+      <div class="card-shimmer" class:shimmer-done={imgLoaded}></div>
       <img
         src={post.image}
         alt={post.title}
         class="card-image"
+        class:img-loaded={imgLoaded}
         loading="lazy"
+        use:checkLoaded
+        onload={() => { imgLoaded = true; }}
+        onerror={() => { imgLoaded = true; }}
       />
     </div>
   {/if}
@@ -70,12 +82,47 @@
     position: relative;
   }
 
+  /* Shimmer */
+  .card-shimmer {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    background: linear-gradient(
+      90deg,
+      #141414 0%,
+      #1e1e1e 40%,
+      #252525 50%,
+      #1e1e1e 60%,
+      #141414 100%
+    );
+    background-size: 200% 100%;
+    animation: card-shimmer-sweep 1.6s ease-in-out infinite;
+    transition: opacity 0.4s ease;
+    pointer-events: none;
+  }
+
+  .card-shimmer.shimmer-done {
+    opacity: 0;
+  }
+
+  @keyframes card-shimmer-sweep {
+    0%   { background-position: 150% 0; }
+    100% { background-position: -150% 0; }
+  }
+
   .card-image {
     width: 100%;
     height: 100%;
     object-fit: cover;
     display: block;
-    transition: transform 0.35s ease;
+    opacity: 0;
+    transition: opacity 0.4s ease, transform 0.35s ease;
+    position: relative;
+    z-index: 2;
+  }
+
+  .card-image.img-loaded {
+    opacity: 1;
   }
 
   .post-card:hover .card-image {

--- a/src/lib/components/ui/Lightbox.svelte
+++ b/src/lib/components/ui/Lightbox.svelte
@@ -1,24 +1,52 @@
 <script lang="ts">
   import { onMount } from 'svelte';
 
-  let {
-    src = '',
-    alt = '',
-    open = false,
-    onclose
-  }: {
+  interface LightboxImage {
     src: string;
     alt: string;
-    open: boolean;
-    onclose: () => void;
-  } = $props();
-
-  // Close on Escape key
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') onclose();
   }
 
-  // Close when clicking the backdrop (not the image itself)
+  let {
+    images = [],
+    index = 0,
+    open = false,
+    onclose,
+    onprev,
+    onnext
+  }: {
+    images: LightboxImage[];
+    index: number;
+    open: boolean;
+    onclose: () => void;
+    onprev?: () => void;
+    onnext?: () => void;
+  } = $props();
+
+  const current = $derived(images[index] ?? { src: '', alt: '' });
+  const hasPrev  = $derived(index > 0);
+  const hasNext  = $derived(index < images.length - 1);
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (!open) return;
+    if (e.key === 'Escape')     onclose();
+    if (e.key === 'ArrowLeft'  && hasPrev) onprev?.();
+    if (e.key === 'ArrowRight' && hasNext) onnext?.();
+  }
+
+  // Swipe tracking
+  let touchStartX = 0;
+
+  function handleTouchStart(e: TouchEvent) {
+    touchStartX = e.touches[0].clientX;
+  }
+
+  function handleTouchEnd(e: TouchEvent) {
+    const delta = e.changedTouches[0].clientX - touchStartX;
+    if (Math.abs(delta) < 50) return;
+    if (delta > 0 && hasPrev) onprev?.();
+    if (delta < 0 && hasNext) onnext?.();
+  }
+
   function handleBackdropClick(e: MouseEvent) {
     if (e.target === e.currentTarget) onclose();
   }
@@ -28,7 +56,6 @@
     return () => window.removeEventListener('keydown', handleKeydown);
   });
 
-  // Lock body scroll while open
   $effect(() => {
     if (open) {
       document.body.style.overflow = 'hidden';
@@ -41,7 +68,15 @@
 
 {#if open}
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-  <div class="lb-backdrop" onclick={handleBackdropClick} role="dialog" aria-modal="true" aria-label="Image lightbox">
+  <div
+    class="lb-backdrop"
+    onclick={handleBackdropClick}
+    ontouchstart={handleTouchStart}
+    ontouchend={handleTouchEnd}
+    role="dialog"
+    aria-modal="true"
+    aria-label="Image lightbox"
+  >
     <button class="lb-close" onclick={onclose} aria-label="Close lightbox">
       <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <line x1="1" y1="1" x2="17" y2="17" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
@@ -49,12 +84,20 @@
       </svg>
     </button>
 
-    <div class="lb-frame">
-      <img class="lb-img" {src} {alt} />
-      {#if alt}
-        <span class="lb-label">{alt}</span>
+    {#if hasPrev}
+      <button class="lb-nav lb-prev" onclick={(e) => { e.stopPropagation(); onprev?.(); }} aria-label="Previous image">‹</button>
+    {/if}
+
+    <div class="lb-frame" onclick={(e) => e.stopPropagation()}>
+      <img class="lb-img" src={current.src} alt={current.alt} />
+      {#if current.alt}
+        <span class="lb-label">{current.alt}</span>
       {/if}
     </div>
+
+    {#if hasNext}
+      <button class="lb-nav lb-next" onclick={(e) => { e.stopPropagation(); onnext?.(); }} aria-label="Next image">›</button>
+    {/if}
   </div>
 {/if}
 
@@ -99,6 +142,34 @@
     color: rgba(200, 192, 184, 1);
   }
 
+  /* Prev / Next arrows */
+  .lb-nav {
+    position: fixed;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 1001;
+    background: none;
+    border: none;
+    color: rgba(200, 192, 184, 0.4);
+    font-size: 3.5rem;
+    font-weight: 100;
+    width: 4rem;
+    height: 6rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: color 0.2s ease;
+    line-height: 1;
+  }
+
+  .lb-prev { left: 0.5rem; }
+  .lb-next { right: 0.5rem; }
+
+  .lb-nav:hover {
+    color: rgba(200, 192, 184, 1);
+  }
+
   .lb-frame {
     max-width: min(90vw, 1200px);
     max-height: 90vh;
@@ -117,7 +188,7 @@
   .lb-img {
     display: block;
     max-width: 100%;
-    max-height: calc(90vh - 2rem); /* leave room for label */
+    max-height: calc(90vh - 2rem);
     width: auto;
     height: auto;
     object-fit: contain;
@@ -153,5 +224,13 @@
       top: 0.75rem;
       right: 1rem;
     }
+
+    .lb-nav {
+      font-size: 2.5rem;
+      width: 3rem;
+    }
+
+    .lb-prev { left: 0.1rem; }
+    .lb-next { right: 0.1rem; }
   }
 </style>

--- a/src/routes/Gallery.svelte
+++ b/src/routes/Gallery.svelte
@@ -18,19 +18,21 @@
 	let error = $state(false);
 
 	// Lightbox state
-	let lbOpen = $state(false);
-	let lbSrc = $state('');
-	let lbAlt = $state('');
+	let lbOpen  = $state(false);
+	let lbIndex = $state(0);
 
-	function openLightbox(image: PortfolioImage) {
-		lbSrc = image.url;
-		lbAlt = image.alt;
-		lbOpen = true;
+	const lbImages = $derived(images.map(img => ({ src: img.url, alt: img.alt })));
+
+	function openLightbox(idx: number) {
+		lbIndex = idx;
+		lbOpen  = true;
 	}
 
-	function closeLightbox() {
-		lbOpen = false;
-	}
+	function closeLightbox() { lbOpen = false; }
+
+	function prevImage() { if (lbIndex > 0) lbIndex--; }
+
+	function nextImage() { if (lbIndex < images.length - 1) lbIndex++; }
 
 	onMount(() => {
 		if (!browser) return () => {};
@@ -73,8 +75,8 @@
 		</div>
 	{:else}
 		<div class="gallery-grid">
-			{#each images as image}
-				<button class="gallery-item" onclick={() => openLightbox(image)} aria-label="View photo">
+			{#each images as image, i}
+				<button class="gallery-item" onclick={() => openLightbox(i)} aria-label="View photo">
 					<img
 						src={image.url}
 						width={image.width}
@@ -91,7 +93,7 @@
 		</div>
 	{/if}
 
-	<Lightbox src={lbSrc} alt={lbAlt} open={lbOpen} onclose={closeLightbox} />
+	<Lightbox images={lbImages} index={lbIndex} open={lbOpen} onclose={closeLightbox} onprev={prevImage} onnext={nextImage} />
 
 	<div class="gallery-cta">
 		<a href="/works" class="view-all-link">

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -8,6 +8,14 @@
   let profileImageError = $state(false);
 </script>
 
+<svelte:head>
+  <title>About — AOKFrames</title>
+  <meta name="description" content="Alain Kouassi is a Seattle-based photographer working in film and digital — capturing the moments just before and after things happen." />
+  <meta property="og:title" content="About — AOKFrames" />
+  <meta property="og:description" content="Alain Kouassi is a Seattle-based photographer working in film and digital — capturing the moments just before and after things happen." />
+  <meta property="og:url" content="https://aokframes.com/about" />
+</svelte:head>
+
 <div class="about-page">
   <Navbar />
 

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -236,6 +236,14 @@
   });
 </script>
 
+<svelte:head>
+  <title>Journal — AOKFrames</title>
+  <meta name="description" content="Writing on photography, film, and the process behind the work — by Alain Kouassi." />
+  <meta property="og:title" content="Journal — AOKFrames" />
+  <meta property="og:description" content="Writing on photography, film, and the process behind the work — by Alain Kouassi." />
+  <meta property="og:url" content="https://aokframes.com/blog" />
+</svelte:head>
+
 <div class="journal-page">
   <Navbar />
 

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -26,6 +26,17 @@
   })();
 </script>
 
+<svelte:head>
+  <title>{data.post.title} — AOKFrames</title>
+  <meta name="description" content={data.post.summary ?? `${data.post.title} — AOKFrames Journal`} />
+  <meta property="og:title" content="{data.post.title} — AOKFrames" />
+  <meta property="og:description" content={data.post.summary ?? `${data.post.title} — AOKFrames Journal`} />
+  <meta property="og:url" content="https://aokframes.com/blog/{data.post.id}" />
+  <meta property="og:image" content="https://assets.aokframes.com/blog/posts/{data.post.id}/header.webp" />
+  <meta name="twitter:title" content="{data.post.title} — AOKFrames" />
+  <meta name="twitter:image" content="https://assets.aokframes.com/blog/posts/{data.post.id}/header.webp" />
+</svelte:head>
+
 <div class="post-page">
   <Navbar />
 

--- a/src/routes/peek/+page.svelte
+++ b/src/routes/peek/+page.svelte
@@ -10,6 +10,14 @@
   const strip2 = $derived(data.images.filter((_: unknown, i: number) => i % 2 !== 0));
 </script>
 
+<svelte:head>
+  <title>Quick-Peek — AOKFrames</title>
+  <meta name="description" content="A rolling preview of recently processed film — images I'm working through before they become a series or get archived." />
+  <meta property="og:title" content="Quick-Peek — AOKFrames" />
+  <meta property="og:description" content="A rolling preview of recently processed film — images I'm working through before they become a series or get archived." />
+  <meta property="og:url" content="https://aokframes.com/peek" />
+</svelte:head>
+
 <div class="peek-page">
   <Navbar />
 
@@ -73,7 +81,7 @@
     font-weight: 300;
     letter-spacing: 0.45em;
     text-transform: uppercase;
-    color: var(--green-light);
+    color: var(--forest-green);
     margin-bottom: 1rem;
   }
 
@@ -133,7 +141,7 @@
     font-size: 9px;
     letter-spacing: 0.25em;
     text-transform: uppercase;
-    color: var(--green-light);
+    color: var(--forest-green);
     opacity: 0.6;
     margin-top: 0.5rem;
   }

--- a/src/routes/prints/+page.svelte
+++ b/src/routes/prints/+page.svelte
@@ -31,6 +31,14 @@
 
 </script>
 
+<svelte:head>
+  <title>Prints &amp; Collabs — AOKFrames</title>
+  <meta name="description" content="Original photography prints and limited edition collaborations from Alain Kouassi." />
+  <meta property="og:title" content="Prints &amp; Collabs — AOKFrames" />
+  <meta property="og:description" content="Original photography prints and limited edition collaborations from Alain Kouassi." />
+  <meta property="og:url" content="https://aokframes.com/prints" />
+</svelte:head>
+
 <div class="prints-page">
   <Navbar />
 

--- a/src/routes/works/+page.svelte
+++ b/src/routes/works/+page.svelte
@@ -106,6 +106,20 @@
     lightboxIndex = (lightboxIndex + 1) % selectedWork.images.length;
   }
 
+  // ── Swipe ────────────────────────────────────────────────────
+  let touchStartX = 0;
+
+  function handleTouchStart(e: TouchEvent) {
+    touchStartX = e.touches[0].clientX;
+  }
+
+  function handleTouchEnd(e: TouchEvent) {
+    const delta = e.changedTouches[0].clientX - touchStartX;
+    if (Math.abs(delta) < 50) return;
+    if (delta > 0) prevImage();
+    else nextImage();
+  }
+
   // ── Keyboard ─────────────────────────────────────────────────
   function handleKeydown(e: KeyboardEvent) {
     if (lightboxIndex !== null) {
@@ -143,6 +157,14 @@
     return () => window.removeEventListener('keydown', handleKeydown);
   });
 </script>
+
+<svelte:head>
+  <title>Works — AOKFrames</title>
+  <meta name="description" content="Selected photography series by Alain Kouassi — film and digital works from 2022 to present." />
+  <meta property="og:title" content="Works — AOKFrames" />
+  <meta property="og:description" content="Selected photography series by Alain Kouassi — film and digital works from 2022 to present." />
+  <meta property="og:url" content="https://aokframes.com/works" />
+</svelte:head>
 
 <div class="works-page">
   <Navbar />
@@ -272,6 +294,8 @@
     aria-modal="true"
     aria-label={`Image ${lightboxIndex + 1} of ${selectedWork.images.length}`}
     onclick={closeLightbox}
+    ontouchstart={handleTouchStart}
+    ontouchend={handleTouchEnd}
   >
     <!-- Prev -->
     <button


### PR DESCRIPTION
## Summary
Four changes in one branch:

1. **Home gallery lightbox navigation** — left/right arrows to browse all portfolio images. No looping: left arrow hidden at index 0, right arrow hidden at the last image.
2. **Swipe support** — 50px horizontal swipe threshold added to both the home page lightbox (`Lightbox.svelte`) and the works page lightbox. Left swipe = next, right swipe = prev.
3. **Peek page CSS bug fix** — `.peek-eyebrow` and `.hover-hint` were using `var(--green-light)` which is undefined in `app.css`. Replaced with `var(--forest-green)`.
4. **Per-page `<title>` and OG meta** — every page now overrides the layout defaults:
   - Works: `Works — AOKFrames`
   - Peek: `Quick-Peek — AOKFrames`
   - Journal: `Journal — AOKFrames`
   - Blog post: `{post.title} — AOKFrames` + `og:image` pointing at `header.webp`
   - About: `About — AOKFrames`
   - Prints: `Prints & Collabs — AOKFrames`

## Test plan
- [ ] Home gallery: click first image → only right arrow shows; click last image → only left arrow shows; middle images show both
- [ ] Arrows navigate to correct adjacent image, no looping
- [ ] Escape and backdrop click still close the lightbox
- [ ] Works page lightbox: swipe left/right navigates images
- [ ] Peek page eyebrow and hover-hint text are visible (green, not invisible)
- [ ] Sharing a blog post link shows the post title and header image in the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
