### PR TITLE
Move Featured Work section from prints to about page

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -74,6 +74,27 @@
 
   <hr class="divider" />
 
+  <!-- Featured Work -->
+  <section class="featured">
+    <div class="featured-inner">
+      <p class="featured-eyebrow">Featured</p>
+      <h2 class="featured-title">Work</h2>
+      <ul class="featured-list">
+        <li>
+          <a
+            href="https://www.ephemere.tokyo/store/p/anarchy2"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Ephemere Anarchy2
+          </a>
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  <hr class="divider" />
+
   <Footer />
 </div>
 
@@ -187,6 +208,66 @@
     margin-bottom: 0;
   }
 
+  /* ── Featured Work ── */
+  .featured {
+    padding: 5rem 5vw;
+  }
+
+  .featured-inner {
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .featured-eyebrow {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-size: 9px;
+    font-weight: 300;
+    letter-spacing: 0.45em;
+    text-transform: uppercase;
+    color: var(--forest-green, #2D4739);
+    margin: 0 0 0.5rem 0;
+  }
+
+  .featured-title {
+    font-family: var(--font-display, 'Cormorant Garamond', Georgia, serif);
+    font-weight: 300;
+    font-style: italic;
+    font-size: clamp(2rem, 3.5vw, 3rem);
+    color: #f0ebe3;
+    margin: 0 0 2rem 0;
+    line-height: 1;
+  }
+
+  .featured-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .featured-list li {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 300;
+    font-size: 13px;
+    color: #c8c0b8;
+  }
+
+  .featured-list a {
+    color: #c8c0b8;
+    text-decoration: none;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid rgba(200, 192, 184, 0.2);
+    padding-bottom: 1px;
+    transition: color 0.2s ease, border-color 0.2s ease;
+  }
+
+  .featured-list a:hover {
+    color: var(--forest-green, #2D4739);
+    border-color: var(--forest-green, #2D4739);
+  }
+
   /* ── Responsive ── */
   @media (max-width: 900px) {
     .bio-inner {
@@ -196,6 +277,10 @@
   }
 
   @media (max-width: 768px) {
+    .featured {
+      padding: 3rem 1.5rem;
+    }
+
     .hero {
       padding: 5rem 1.5rem 3rem;
       min-height: unset;

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -216,6 +216,7 @@
   .featured-inner {
     max-width: 1100px;
     margin: 0 auto;
+    text-align: center;
   }
 
   .featured-eyebrow {
@@ -244,6 +245,7 @@
     margin: 0;
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 0.75rem;
   }
 

--- a/src/routes/prints/+page.svelte
+++ b/src/routes/prints/+page.svelte
@@ -118,21 +118,6 @@
         </a>
       </div>
 
-      <!-- Featured work -->
-      <div class="featured">
-        <h2 class="featured-title">Featured Work</h2>
-        <ul class="featured-list">
-          <li>
-            <a
-              href="https://www.ephemere.tokyo/store/p/anarchy2"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Ephemere Anarchy2
-            </a>
-          </li>
-        </ul>
-      </div>
     </div>
   </section>
 
@@ -278,47 +263,6 @@
   .btn-bordered:hover {
     background-color: var(--forest-green, #2D4739);
     color: var(--warm-white, #f0ebe3);
-  }
-
-  /* ── Featured work ── */
-  .featured {
-    width: 100%;
-    text-align: center;
-  }
-
-  .featured-title {
-    font-family: var(--font-display, 'Cormorant Garamond', Georgia, serif);
-    font-weight: 300;
-    font-size: 1.6rem;
-    color: #f0ebe3;
-    margin: 0 0 1rem 0;
-  }
-
-  .featured-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-  }
-
-  .featured-list li {
-    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
-    font-weight: 300;
-    font-size: 13px;
-    color: #c8c0b8;
-    margin-bottom: 0.5rem;
-  }
-
-  .featured-list a {
-    color: #c8c0b8;
-    text-decoration: none;
-    letter-spacing: 0.05em;
-    border-bottom: 1px solid rgba(200, 192, 184, 0.2);
-    transition: color 0.2s, border-color 0.2s;
-  }
-
-  .featured-list a:hover {
-    color: var(--forest-green, #2D4739);
-    border-color: var(--forest-green, #2D4739);
   }
 
   /* ── Responsive ── */


### PR DESCRIPTION
﻿## Summary
- Removes the Featured Work block from the Prints & Collabs page CTA section
- Adds it to the About page, below the bio, separated by dividers so it reads as its own distinct section
- Preserves all existing links and styling (forest-green eyebrow, italic display title, underline-on-hover links)

## Test plan
- [ ] Visit `/about` — Featured Work section appears below the bio/quote, separated by dividers
- [ ] Visit `/prints` — Featured Work block is gone; CTA buttons remain intact
- [ ] Check mobile layout on both pages
- [ ] Verify Ephemere Anarchy2 link opens correctly in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
