### PR TITLE
Retheme 404/error pages to match current site design

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,52 +1,101 @@
 <script lang="ts">
   import { page } from '$app/stores';
+  import Navbar from '$lib/components/ui/navbar.svelte';
+  import Footer from '$lib/components/ui/footer.svelte';
+
+  const status = $derived($page.status);
+  const message = $derived(
+    status === 404
+      ? "This page doesn't exist."
+      : "Something went wrong."
+  );
 </script>
 
-<div class="error-content">
-  <h1>404</h1>
-  <p>Sorry, this page doesn't exist. There may be a typo in the URL or the page may have been moved.</p>
-  <p>You can return home by clicking <a href="/">here</a>.</p>
+<svelte:head>
+  <title>{status} — AOKFrames</title>
+</svelte:head>
+
+<div class="error-page">
+  <Navbar />
+
+  <main class="error-main">
+    <p class="error-eyebrow">Error</p>
+    <h1 class="error-code">{status}</h1>
+    <p class="error-message">{message}</p>
+    <a href="/" class="btn-bordered">Back to Home</a>
+  </main>
+
+  <Footer />
 </div>
 
 <style>
-  .error-content {
+  .error-page {
+    min-height: 100vh;
+    background-color: #0e0e0e;
+    color: #f0ebe3;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .error-main {
     flex: 1;
     display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
     text-align: center;
-    padding: 2rem;
-    min-height: 80vh;
+    padding: 8rem 2rem 6rem;
+    gap: 1.5rem;
   }
 
-  h1 {
-    font-size: 6rem;
+  .error-eyebrow {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-size: 9px;
     font-weight: 300;
+    letter-spacing: 0.45em;
+    text-transform: uppercase;
+    color: var(--forest-green, #2D4739);
     margin: 0;
-    color: #666;
   }
 
-  p {
-    font-size: 1.5rem;
+  .error-code {
+    font-family: var(--font-display, 'Cormorant Garamond', Georgia, serif);
+    font-weight: 300;
+    font-style: italic;
+    font-size: clamp(6rem, 18vw, 14rem);
+    line-height: 1;
+    letter-spacing: -0.02em;
+    color: rgba(200, 192, 184, 0.12);
+    margin: 0;
+  }
+
+  .error-message {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 300;
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(200, 192, 184, 0.7);
+    margin: 0;
+  }
+
+  .btn-bordered {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 400;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.25em;
+    color: var(--forest-green, #2D4739);
+    border: 1px solid var(--forest-green, #2D4739);
+    padding: 0.75rem 2rem;
+    text-decoration: none;
+    display: inline-block;
     margin-top: 1rem;
+    transition: background-color 0.2s ease, color 0.2s ease;
   }
 
-  a {
-    font-weight: bold;
-    text-decoration: underline;
+  .btn-bordered:hover {
+    background-color: var(--forest-green, #2D4739);
+    color: var(--warm-white, #f0ebe3);
   }
-
-  a:hover {
-    opacity: 0.8;
-  }
-
-  @media (max-width: 768px) {
-    h1 {
-      font-size: 3rem;
-    }
-    p {
-      font-size: 1rem;
-    }
-  }
-</style> 
+</style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -21,7 +21,15 @@
   <main class="error-main">
     <p class="error-eyebrow">Error</p>
     <h1 class="error-code">{status}</h1>
-    <p class="error-message">{message}</p>
+    <div class="error-message">
+      {#if status === 404}
+        <p>Sorry, this page doesn't exist. It's probably hidden somewhere with Kodak Aerochrome.</p>
+        <p>There may be a typo in the URL or the page may have been moved.</p>
+        <p>You can return home by clicking <a href="/">here</a>.</p>
+      {:else}
+        <p>{message}</p>
+      {/if}
+    </div>
     <a href="/" class="btn-bordered">Back to Home</a>
   </main>
 
@@ -70,13 +78,26 @@
   }
 
   .error-message {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 0;
+  }
+
+  .error-message p {
     font-family: var(--font-ui, 'Josefin Sans', sans-serif);
     font-weight: 300;
-    font-size: 0.75rem;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.15em;
     color: rgba(200, 192, 184, 0.7);
     margin: 0;
+    line-height: 1.8;
+  }
+
+  .error-message a {
+    color: var(--forest-green, #2D4739);
+    text-decoration: underline;
+    text-underline-offset: 3px;
   }
 
   .btn-bordered {

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -25,7 +25,6 @@
       {#if status === 404}
         <p>Sorry, this page doesn't exist. It's probably hidden somewhere with Kodak Aerochrome.</p>
         <p>There may be a typo in the URL or the page may have been moved.</p>
-        <p>You can return home by clicking <a href="/">here</a>.</p>
       {:else}
         <p>{message}</p>
       {/if}

--- a/src/routes/[...path]/+page.svelte
+++ b/src/routes/[...path]/+page.svelte
@@ -1,68 +1,93 @@
 <script lang="ts">
-  import { theme } from '../../theme/theme.js';
   import Footer from "$lib/components/ui/footer.svelte";
   import Navbar from "$lib/components/ui/navbar.svelte";
 </script>
 
-<div class="error-container" style="--bg-color: {theme.background.light}; --text-color: {theme.text.primary};">
-  <Navbar 
-    backgroundColor={theme.text.primary}
-    textColor={theme.background.light}
-  />
-  <div class="error-content">
-    <h1>404</h1>
-    <p>Sorry, this page doesn't exist. There may be a typo in the URL or the page may have been moved.</p>
-    <p>You can return home by clicking <a href="/">here</a>.</p>
-  </div>
+<svelte:head>
+  <title>404 — AOKFrames</title>
+</svelte:head>
+
+<div class="error-page">
+  <Navbar />
+
+  <main class="error-main">
+    <p class="error-eyebrow">Error</p>
+    <h1 class="error-code">404</h1>
+    <p class="error-message">This page doesn't exist.</p>
+    <a href="/" class="btn-bordered">Back to Home</a>
+  </main>
+
   <Footer />
 </div>
 
 <style>
-  .error-container {
+  .error-page {
     min-height: 100vh;
-    width: 100%;
-    background-color: var(--bg-color);
-    color: var(--text-color);
+    background-color: #0e0e0e;
+    color: #f0ebe3;
     display: flex;
     flex-direction: column;
   }
 
-  .error-content {
+  .error-main {
     flex: 1;
     display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
     text-align: center;
-    padding: 2rem;
+    padding: 8rem 2rem 6rem;
+    gap: 1.5rem;
   }
 
-  h1 {
-    font-size: 6rem;
+  .error-eyebrow {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-size: 9px;
     font-weight: 300;
+    letter-spacing: 0.45em;
+    text-transform: uppercase;
+    color: var(--forest-green, #2D4739);
     margin: 0;
   }
 
-  p {
-    font-size: 1.5rem;
+  .error-code {
+    font-family: var(--font-display, 'Cormorant Garamond', Georgia, serif);
+    font-weight: 300;
+    font-style: italic;
+    font-size: clamp(6rem, 18vw, 14rem);
+    line-height: 1;
+    letter-spacing: -0.02em;
+    color: rgba(200, 192, 184, 0.12);
+    margin: 0;
+  }
+
+  .error-message {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 300;
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(200, 192, 184, 0.7);
+    margin: 0;
+  }
+
+  .btn-bordered {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 400;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.25em;
+    color: var(--forest-green, #2D4739);
+    border: 1px solid var(--forest-green, #2D4739);
+    padding: 0.75rem 2rem;
+    text-decoration: none;
+    display: inline-block;
     margin-top: 1rem;
+    transition: background-color 0.2s ease, color 0.2s ease;
   }
 
-  a {
-    color: color-mix(in srgb, var(--text-color) 80%, black);
+  .btn-bordered:hover {
+    background-color: var(--forest-green, #2D4739);
+    color: var(--warm-white, #f0ebe3);
   }
-
-  a:hover {
-    opacity: 0.8;
-    text-decoration: underline;
-  }
-
-  @media (max-width: 768px) {
-    h1 {
-      font-size: 3rem;
-    }
-    p {
-      font-size: 1rem;
-    }
-  }
-</style> 
+</style>

--- a/src/routes/[...path]/+page.svelte
+++ b/src/routes/[...path]/+page.svelte
@@ -16,7 +16,6 @@
     <div class="error-message">
       <p>Sorry, this page doesn't exist. It's probably hidden somewhere with Kodak Aerochrome.</p>
       <p>There may be a typo in the URL or the page may have been moved.</p>
-      <p>You can return home by clicking <a href="/">here</a>.</p>
     </div>
     <a href="/" class="btn-bordered">Back to Home</a>
   </main>

--- a/src/routes/[...path]/+page.svelte
+++ b/src/routes/[...path]/+page.svelte
@@ -13,7 +13,11 @@
   <main class="error-main">
     <p class="error-eyebrow">Error</p>
     <h1 class="error-code">404</h1>
-    <p class="error-message">This page doesn't exist.</p>
+    <div class="error-message">
+      <p>Sorry, this page doesn't exist. It's probably hidden somewhere with Kodak Aerochrome.</p>
+      <p>There may be a typo in the URL or the page may have been moved.</p>
+      <p>You can return home by clicking <a href="/">here</a>.</p>
+    </div>
     <a href="/" class="btn-bordered">Back to Home</a>
   </main>
 
@@ -62,13 +66,26 @@
   }
 
   .error-message {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 0;
+  }
+
+  .error-message p {
     font-family: var(--font-ui, 'Josefin Sans', sans-serif);
     font-weight: 300;
-    font-size: 0.75rem;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.15em;
     color: rgba(200, 192, 184, 0.7);
     margin: 0;
+    line-height: 1.8;
+  }
+
+  .error-message a {
+    color: var(--forest-green, #2D4739);
+    text-decoration: underline;
+    text-underline-offset: 3px;
   }
 
   .btn-bordered {

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -4,7 +4,6 @@
   import BlogPostComponent from '$lib/components/blog/BlogPost.svelte';
   import { posts } from '../../lib/stores/blog.js';
   import { assetUrl } from '$lib/utils/r2.js';
-  import { theme } from '../../theme/theme.js';
   import type { PageData } from './$types.js';
   import { onMount } from 'svelte';
   import type { BlogPost as BlogPostType } from '$lib/types/blog.js';

--- a/src/routes/blog/[slug]/+error.svelte
+++ b/src/routes/blog/[slug]/+error.svelte
@@ -1,51 +1,93 @@
 <script lang="ts">
   import Navbar from '$lib/components/ui/navbar.svelte';
   import Footer from '$lib/components/ui/footer.svelte';
-  import { theme } from '../../../theme/theme.js';
-  import { page } from '$app/stores';
 </script>
 
-<Navbar 
-  backgroundColor={theme.text.primary}
-  textColor={theme.background.light}
-/>
+<svelte:head>
+  <title>Post Not Found — AOKFrames</title>
+</svelte:head>
 
-<main class="min-h-screen py-16 pt-24 md:pt-20" style="background-color: {theme.background.light}; color: {theme.text.primary};">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="mb-8 mt-4 md:mt-0">
-      <a
-        href="/blog"
-        class="inline-flex items-center hover:opacity-80"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-5 w-5 mr-2"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M7.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l2.293 2.293a1 1 0 010 1.414z"
-            clip-rule="evenodd"
-          />
-        </svg>
-        Back to Blog
-      </a>
-    </div>
+<div class="error-page">
+  <Navbar />
 
-    <div class="text-center py-16">
-      <p class="text-gray-600">
-        The blog post you're looking for doesn't exist.
-      </p>
-    </div>
-  </div>
-</main>
+  <main class="error-main">
+    <p class="error-eyebrow">Journal</p>
+    <h1 class="error-code">404</h1>
+    <p class="error-message">This post doesn't exist.</p>
+    <a href="/blog" class="btn-bordered">Back to Journal</a>
+  </main>
 
-<Footer /> 
+  <Footer />
+</div>
 
 <style>
-  p {
-    font-size: 1.5rem;
+  .error-page {
+    min-height: 100vh;
+    background-color: #0e0e0e;
+    color: #f0ebe3;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .error-main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 8rem 2rem 6rem;
+    gap: 1.5rem;
+  }
+
+  .error-eyebrow {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-size: 9px;
+    font-weight: 300;
+    letter-spacing: 0.45em;
+    text-transform: uppercase;
+    color: var(--forest-green, #2D4739);
+    margin: 0;
+  }
+
+  .error-code {
+    font-family: var(--font-display, 'Cormorant Garamond', Georgia, serif);
+    font-weight: 300;
+    font-style: italic;
+    font-size: clamp(6rem, 18vw, 14rem);
+    line-height: 1;
+    letter-spacing: -0.02em;
+    color: rgba(200, 192, 184, 0.12);
+    margin: 0;
+  }
+
+  .error-message {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 300;
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(200, 192, 184, 0.7);
+    margin: 0;
+  }
+
+  .btn-bordered {
+    font-family: var(--font-ui, 'Josefin Sans', sans-serif);
+    font-weight: 400;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.25em;
+    color: var(--forest-green, #2D4739);
+    border: 1px solid var(--forest-green, #2D4739);
+    padding: 0.75rem 2rem;
+    text-decoration: none;
+    display: inline-block;
     margin-top: 1rem;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .btn-bordered:hover {
+    background-color: var(--forest-green, #2D4739);
+    color: var(--warm-white, #f0ebe3);
   }
 </style>

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -4,13 +4,9 @@
   import BlogPost from '$lib/components/blog/BlogPost.svelte';
   import { assetUrl } from '$lib/utils/r2.js';
   import type { BlogPost as BlogPostType } from '$lib/types/blog.js';
-  import { theme } from '../../../theme/theme.js';
   import { marked } from 'marked';
 
   export let data: { post: BlogPostType };
-
-  // Get tertiary color for inline style
-  $: tertiaryColor = theme.tertiary;
 
   // Render markdown content to HTML, rewriting relative img srcs to CDN URLs
   $: htmlContent = (() => {

--- a/src/routes/prints/+page.svelte
+++ b/src/routes/prints/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { theme } from '../../theme/theme.js'; // Relative path to theme
   import { Footer, Navbar } from "$lib/components/ui/index.js";
   import { assetUrl } from '$lib/utils/r2.js';
   import { onMount, afterUpdate } from 'svelte'; // Import lifecycle hooks


### PR DESCRIPTION
﻿## Summary
- Replaces both old error pages (root `+error.svelte` and `blog/[slug]/+error.svelte`) with the current dark site design
- `#0e0e0e` background, `#f0ebe3` warm white text — no more light/white theming
- Giant italic Cormorant Garamond 404 numeral in a very dim tone (acts as a decorative element)
- Josefin Sans eyebrow label + message in the same style as all other pages
- Forest-green bordered CTA button matching Prints, About, etc.
- Drops all old Tailwind utility classes and legacy theme imports
- Root error page dynamically shows the HTTP status code and adapts the message (404 vs generic)
- Blog error page routes back to Journal instead of the generic home

## Test plan
- [ ] Navigate to a nonexistent URL (e.g. `/does-not-exist`) — should show dark 404 page with Navbar, Footer, and "Back to Home" button
- [ ] Navigate to a nonexistent blog slug (e.g. `/blog/not-a-real-post`) — should show dark 404 page with "Back to Journal" button
- [ ] Verify Navbar and Footer render correctly on both error pages
- [ ] Check mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
