### PR TITLE
Brighten Featured eyebrow on about page

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -225,7 +225,7 @@
     font-weight: 300;
     letter-spacing: 0.45em;
     text-transform: uppercase;
-    color: var(--forest-green, #2D4739);
+    color: #6a9e82;
     margin: 0 0 0.5rem 0;
   }
 


### PR DESCRIPTION
﻿## Summary
- Brightens the "Featured" eyebrow label on the about page from dark forest green (`#2D4739`) to the lighter sage green (`#6a9e82`) already used for the pull quote — making it clearly readable against the dark background.

## Test plan
- [ ] Visit `/about` and scroll to the Featured Work section — "FEATURED" eyebrow should be visibly brighter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
